### PR TITLE
Fix linters and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ build: deps schema
 
 .PHONY: test
 test:
-	go test -v -race - ./...
+	go test -v -race ./...
 
 .PHONY: test-cover
 test-cover:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/plainq/plainq
 
-go 1.25
+go 1.24
 
 require (
 	github.com/VictoriaMetrics/metrics v1.35.1

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cockroachdb/swiss v0.0.0-20250624142022-d6e517c1d961 h1:Nua446ru3juLHLZd4AwKNzClZgL1co3pUPGv3o8FlcA=
 github.com/cockroachdb/swiss v0.0.0-20250624142022-d6e517c1d961/go.mod h1:yBRu/cnL4ks9bgy4vAASdjIW+/xMlFwuHKqtmh3GZQg=
+github.com/cristalhq/jwt/v5 v5.4.0 h1:Wxi1TocFHaijyV608j7v7B9mPc4ZNjvWT3LKBO0d4QI=
+github.com/cristalhq/jwt/v5 v5.4.0/go.mod h1:+b/BzaCWEpFDmXxspJ5h4SdJ1N/45KMjKOetWzmHvDA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/server/http_transport.go
+++ b/internal/server/http_transport.go
@@ -63,6 +63,7 @@ func (s *PlainQ) listQueuesHandler(w http.ResponseWriter, r *http.Request) {
 			respond.ErrorHTTP(w, r, fmt.Errorf("%w: limit value too large", errkit.ErrInvalidArgument))
 			return
 		}
+		//nolint:gosec // Safe: value checked against MaxInt32 above
 		input.Limit = int32(limit)
 	}
 
@@ -145,17 +146,4 @@ func (*PlainQ) houstonStaticHandler(w http.ResponseWriter, r *http.Request) {
 	pathPrefix := strings.TrimSuffix(routeCtx.RoutePattern(), "/*")
 
 	http.StripPrefix(pathPrefix, http.FileServerFS(houston.Bundle())).ServeHTTP(w, r)
-}
-
-func dropPolicyToString(policy v1.EvictionPolicy) string {
-	switch policy {
-	case v1.EvictionPolicy_EVICTION_POLICY_DROP:
-		return "Drop Message"
-
-	case v1.EvictionPolicy_EVICTION_POLICY_DEAD_LETTER:
-		return "Dead Letter Queue"
-
-	default:
-		return ""
-	}
 }

--- a/internal/server/storage/litestore/auth_storage.go
+++ b/internal/server/storage/litestore/auth_storage.go
@@ -15,7 +15,7 @@ var _ auth.AuthStorage = (*Storage)(nil)
 
 // CreateUser creates a new user
 func (s *Storage) CreateUser(ctx context.Context, email, passwordHash string) (*auth.User, error) {
-	userID := idkit.NewID()
+	userID := idkit.XID()
 	now := time.Now()
 
 	query := `
@@ -205,7 +205,7 @@ func (s *Storage) MarkSetupCompleted(ctx context.Context) error {
 
 // CreateRefreshToken creates a new refresh token
 func (s *Storage) CreateRefreshToken(ctx context.Context, userID, tokenHash string, expiresAt time.Time, deviceInfo, ipAddress string) (*auth.RefreshToken, error) {
-	tokenID := idkit.NewID()
+	tokenID := idkit.XID()
 	now := time.Now()
 
 	query := `
@@ -408,7 +408,7 @@ func (s *Storage) CleanupExpiredDeniedTokens(ctx context.Context) error {
 
 // LogAuthEvent logs an authentication event
 func (s *Storage) LogAuthEvent(ctx context.Context, userID, eventType string, success bool, ipAddress, userAgent, metadata string) error {
-	logID := idkit.NewID()
+	logID := idkit.XID()
 
 	query := `
 		INSERT INTO auth_audit_log (log_id, user_id, event_type, success, ip_address, user_agent, metadata, created_at)
@@ -429,7 +429,7 @@ func (s *Storage) LogAuthEvent(ctx context.Context, userID, eventType string, su
 
 // CreateOAuthProvider creates a new OAuth provider
 func (s *Storage) CreateOAuthProvider(ctx context.Context, provider *auth.OAuthProvider) error {
-	provider.ProviderID = idkit.NewID()
+	provider.ProviderID = idkit.XID()
 	provider.CreatedAt = time.Now()
 	provider.UpdatedAt = time.Now()
 
@@ -576,7 +576,7 @@ func (s *Storage) UpdateOAuthProvider(ctx context.Context, provider *auth.OAuthP
 
 // CreateOAuthConnection creates a new OAuth connection
 func (s *Storage) CreateOAuthConnection(ctx context.Context, conn *auth.OAuthConnection) error {
-	conn.ConnectionID = idkit.NewID()
+	conn.ConnectionID = idkit.XID()
 	conn.CreatedAt = time.Now()
 	conn.UpdatedAt = time.Now()
 


### PR DESCRIPTION
- Update Go version from 1.25 to 1.24 in go.mod
- Fix Makefile test command by removing stray dash
- Fix server.Context() error by using context.Background()
- Replace idkit.NewID() with idkit.XID() in auth_storage.go
- Fix linter issues:
  - Add periods to comments (godot)
  - Add comment for blank import
  - Rename parameter to avoid shadowing import
  - Use errors.New instead of fmt.Errorf
  - Extract magic number to constant
  - Add nolint comment for safe integer conversion
  - Remove unused dropPolicyToString function
  - Format code with gofmt