### PR TITLE
feat: Implement RBAC and OAuth provider integration

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -180,6 +180,10 @@ func serverCommand() *scotty.Command {
 			f.StringVar(&cfg.AuthIssuer, "auth.issuer", "plainq",
 				"JWT issuer identifier",
 			)
+
+			f.StringVar(&cfg.AuthOAuthBaseURL, "auth.oauth-base-url", "http://localhost:8081",
+				"Base URL for OAuth callbacks (e.g., https://example.com)",
+			)
 		},
 
 		Run: func(_ *scotty.Command, _ []string) error {

--- a/internal/server/auth/handlers.go
+++ b/internal/server/auth/handlers.go
@@ -350,13 +350,13 @@ func (h *Handler) SetupStatus(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// OAuthProviderResponse represents an OAuth provider in the API response
+// OAuthProviderResponse represents an OAuth provider in the API response.
 type OAuthProviderResponse struct {
 	Name string `json:"name"`
 	Type string `json:"type"`
 }
 
-// ListOAuthProviders returns a list of enabled OAuth providers
+// ListOAuthProviders returns a list of enabled OAuth providers.
 func (h *Handler) ListOAuthProviders(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, `{"error": "method not allowed"}`, http.StatusMethodNotAllowed)
@@ -383,12 +383,12 @@ func (h *Handler) ListOAuthProviders(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// OAuthInitRequest represents a request to initiate OAuth flow
+// OAuthInitRequest represents a request to initiate OAuth flow.
 type OAuthInitRequest struct {
 	Provider string `json:"provider"`
 }
 
-// OAuthInit initiates the OAuth flow by returning the authorization URL
+// OAuthInit initiates the OAuth flow by returning the authorization URL.
 func (h *Handler) OAuthInit(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, `{"error": "method not allowed"}`, http.StatusMethodNotAllowed)
@@ -431,7 +431,7 @@ func (h *Handler) OAuthInit(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// OAuthCallback handles the OAuth callback from the provider
+// OAuthCallback handles the OAuth callback from the provider.
 func (h *Handler) OAuthCallback(w http.ResponseWriter, r *http.Request, providerName string) {
 	if h.oauthService == nil {
 		http.Error(w, `{"error": "OAuth not configured"}`, http.StatusServiceUnavailable)
@@ -477,7 +477,7 @@ func (h *Handler) OAuthCallback(w http.ResponseWriter, r *http.Request, provider
 	json.NewEncoder(w).Encode(response)
 }
 
-// generateOAuthState generates a secure random state parameter for OAuth
+// generateOAuthState generates a secure random state parameter for OAuth.
 func generateOAuthState() (string, error) {
 	bytes := make([]byte, 32)
 	if _, err := rand.Read(bytes); err != nil {

--- a/internal/server/auth/jwt.go
+++ b/internal/server/auth/jwt.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// Token durations
-	AccessTokenDuration  = 15 * time.Minute  // Short-lived access tokens
+	AccessTokenDuration  = 15 * time.Minute   // Short-lived access tokens
 	RefreshTokenDuration = 7 * 24 * time.Hour // Long-lived refresh tokens
 )
 

--- a/internal/server/auth/oauth.go
+++ b/internal/server/auth/oauth.go
@@ -10,14 +10,14 @@ import (
 	"strings"
 )
 
-// OAuthService handles OAuth provider integrations
+// OAuthService handles OAuth provider integrations.
 type OAuthService struct {
 	storage     AuthStorage
 	authService *AuthService
 	baseURL     string // Base URL for OAuth callbacks (e.g., "https://example.com")
 }
 
-// NewOAuthService creates a new OAuth service
+// NewOAuthService creates a new OAuth service.
 func NewOAuthService(storage AuthStorage, authService *AuthService, baseURL string) *OAuthService {
 	// Ensure baseURL doesn't have trailing slash
 	baseURL = strings.TrimSuffix(baseURL, "/")
@@ -31,12 +31,12 @@ func NewOAuthService(storage AuthStorage, authService *AuthService, baseURL stri
 	}
 }
 
-// GetRedirectURL returns the OAuth redirect URL for a provider
+// GetRedirectURL returns the OAuth redirect URL for a provider.
 func (s *OAuthService) GetRedirectURL(providerName string) string {
 	return fmt.Sprintf("%s/api/v1/auth/oauth/%s/callback", s.baseURL, providerName)
 }
 
-// OAuthConfig represents OAuth configuration for a provider
+// OAuthConfig represents OAuth configuration for a provider.
 type OAuthConfig struct {
 	ClientID     string
 	ClientSecret string
@@ -47,7 +47,7 @@ type OAuthConfig struct {
 	UserinfoURL  string
 }
 
-// GetAuthorizationURL generates the OAuth authorization URL
+// GetAuthorizationURL generates the OAuth authorization URL.
 func (s *OAuthService) GetAuthorizationURL(providerName, state string) (string, error) {
 	provider, err := s.storage.GetOAuthProvider(context.Background(), providerName)
 	if err != nil {
@@ -84,7 +84,7 @@ func (s *OAuthService) GetAuthorizationURL(providerName, state string) (string, 
 	return authURL + "?" + params.Encode(), nil
 }
 
-// ExchangeCodeForToken exchanges an authorization code for tokens
+// ExchangeCodeForToken exchanges an authorization code for tokens.
 func (s *OAuthService) ExchangeCodeForToken(ctx context.Context, providerName, code string) (map[string]interface{}, error) {
 	provider, err := s.storage.GetOAuthProvider(ctx, providerName)
 	if err != nil {
@@ -136,7 +136,7 @@ func (s *OAuthService) ExchangeCodeForToken(ctx context.Context, providerName, c
 	return tokenResponse, nil
 }
 
-// GetUserInfo retrieves user information from the OAuth provider
+// GetUserInfo retrieves user information from the OAuth provider.
 func (s *OAuthService) GetUserInfo(ctx context.Context, providerName, accessToken string) (map[string]interface{}, error) {
 	provider, err := s.storage.GetOAuthProvider(ctx, providerName)
 	if err != nil {
@@ -180,7 +180,7 @@ func (s *OAuthService) GetUserInfo(ctx context.Context, providerName, accessToke
 	return userInfo, nil
 }
 
-// HandleCallback processes the OAuth callback and creates/links user account
+// HandleCallback processes the OAuth callback and creates/links user account.
 func (s *OAuthService) HandleCallback(ctx context.Context, providerName, code, deviceInfo, ipAddress string) (*LoginResult, error) {
 	// Exchange code for tokens
 	tokenResponse, err := s.ExchangeCodeForToken(ctx, providerName, code)

--- a/internal/server/auth/password.go
+++ b/internal/server/auth/password.go
@@ -10,11 +10,11 @@ import (
 
 const (
 	// Argon2 parameters (OWASP recommended values for interactive logins)
-	argon2Time      = 2       // Number of iterations
+	argon2Time      = 2         // Number of iterations
 	argon2Memory    = 64 * 1024 // 64 MB
-	argon2Threads   = 4       // Number of threads
-	argon2KeyLength = 32      // 32 bytes = 256 bits
-	saltLength      = 16      // 16 bytes = 128 bits
+	argon2Threads   = 4         // Number of threads
+	argon2KeyLength = 32        // 32 bytes = 256 bits
+	saltLength      = 16        // 16 bytes = 128 bits
 )
 
 // HashPassword hashes a plaintext password using Argon2id

--- a/internal/server/auth/permission.go
+++ b/internal/server/auth/permission.go
@@ -1,0 +1,86 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+)
+
+// PermissionService handles queue permission checks
+type PermissionService struct {
+	storage AuthStorage
+}
+
+// NewPermissionService creates a new permission service
+func NewPermissionService(storage AuthStorage) *PermissionService {
+	return &PermissionService{storage: storage}
+}
+
+// CheckQueuePermission checks if a user with the given roles has permission to perform an action on a queue.
+// Admins have full access to all queues regardless of specific permissions.
+func (s *PermissionService) CheckQueuePermission(ctx context.Context, queueID string, roles []string, action PermissionAction) error {
+	// Admin role has full access to all queues
+	for _, role := range roles {
+		if role == "admin" {
+			return nil
+		}
+	}
+
+	// Get role IDs from role names
+	roleIDs := make([]string, 0, len(roles))
+	for _, roleName := range roles {
+		role, err := s.storage.GetRoleByName(ctx, roleName)
+		if err != nil {
+			continue // Skip roles that don't exist
+		}
+		roleIDs = append(roleIDs, role.RoleID)
+	}
+
+	if len(roleIDs) == 0 {
+		return fmt.Errorf("no valid roles found")
+	}
+
+	// Get permissions for this queue and user's roles
+	perm, err := s.storage.GetQueuePermissions(ctx, queueID, roleIDs)
+	if err != nil {
+		return fmt.Errorf("failed to get permissions: %w", err)
+	}
+
+	// Check specific action permission
+	switch action {
+	case ActionSend:
+		if !perm.CanSend {
+			return fmt.Errorf("permission denied: cannot send to queue")
+		}
+	case ActionReceive:
+		if !perm.CanReceive {
+			return fmt.Errorf("permission denied: cannot receive from queue")
+		}
+	case ActionPurge:
+		if !perm.CanPurge {
+			return fmt.Errorf("permission denied: cannot purge queue")
+		}
+	case ActionDelete:
+		if !perm.CanDelete {
+			return fmt.Errorf("permission denied: cannot delete queue")
+		}
+	default:
+		return fmt.Errorf("unknown action: %s", action)
+	}
+
+	return nil
+}
+
+// HasRole checks if the given roles contain a specific role
+func HasRole(roles []string, targetRole string) bool {
+	for _, role := range roles {
+		if role == targetRole {
+			return true
+		}
+	}
+	return false
+}
+
+// IsAdmin checks if the user has admin role
+func IsAdmin(roles []string) bool {
+	return HasRole(roles, "admin")
+}

--- a/internal/server/auth/permission.go
+++ b/internal/server/auth/permission.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 )
 
-// PermissionService handles queue permission checks
+// PermissionService handles queue permission checks.
 type PermissionService struct {
 	storage AuthStorage
 }
 
-// NewPermissionService creates a new permission service
+// NewPermissionService creates a new permission service.
 func NewPermissionService(storage AuthStorage) *PermissionService {
 	return &PermissionService{storage: storage}
 }
@@ -70,7 +70,7 @@ func (s *PermissionService) CheckQueuePermission(ctx context.Context, queueID st
 	return nil
 }
 
-// HasRole checks if the given roles contain a specific role
+// HasRole checks if the given roles contain a specific role.
 func HasRole(roles []string, targetRole string) bool {
 	for _, role := range roles {
 		if role == targetRole {
@@ -80,7 +80,7 @@ func HasRole(roles []string, targetRole string) bool {
 	return false
 }
 
-// IsAdmin checks if the user has admin role
+// IsAdmin checks if the user has admin role.
 func IsAdmin(roles []string) bool {
 	return HasRole(roles, "admin")
 }

--- a/internal/server/auth/service.go
+++ b/internal/server/auth/service.go
@@ -8,9 +8,9 @@ import (
 
 // AuthService handles authentication operations
 type AuthService struct {
-	storage   AuthStorage
-	jwt       *JWTService
-	denyList  *TokenDenyList
+	storage  AuthStorage
+	jwt      *JWTService
+	denyList *TokenDenyList
 }
 
 // NewAuthService creates a new authentication service

--- a/internal/server/auth/storage.go
+++ b/internal/server/auth/storage.go
@@ -72,7 +72,7 @@ type OAuthConnection struct {
 	UpdatedAt      time.Time
 }
 
-// QueuePermission represents permissions for a role on a specific queue
+// QueuePermission represents permissions for a role on a specific queue.
 type QueuePermission struct {
 	QueueID    string
 	RoleID     string
@@ -84,7 +84,7 @@ type QueuePermission struct {
 	UpdatedAt  time.Time
 }
 
-// PermissionAction represents an action that can be performed on a queue
+// PermissionAction represents an action that can be performed on a queue.
 type PermissionAction string
 
 const (

--- a/internal/server/auth/storage.go
+++ b/internal/server/auth/storage.go
@@ -38,23 +38,23 @@ type RefreshToken struct {
 
 // OAuthProvider represents an OAuth/OIDC provider configuration
 type OAuthProvider struct {
-	ProviderID     string
-	ProviderName   string
-	ProviderType   string
-	Enabled        bool
-	ClientID       string
-	ClientSecret   string
-	IssuerURL      string
-	AuthURL        string
-	TokenURL       string
-	UserinfoURL    string
-	JWKSURL        string
-	Scopes         string
+	ProviderID      string
+	ProviderName    string
+	ProviderType    string
+	Enabled         bool
+	ClientID        string
+	ClientSecret    string
+	IssuerURL       string
+	AuthURL         string
+	TokenURL        string
+	UserinfoURL     string
+	JWKSURL         string
+	Scopes          string
 	SAMLMetadataURL string
-	SAMLEntityID   string
-	ConfigJSON     string
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
+	SAMLEntityID    string
+	ConfigJSON      string
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
 }
 
 // OAuthConnection represents a user's connection to an OAuth provider
@@ -71,6 +71,28 @@ type OAuthConnection struct {
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
 }
+
+// QueuePermission represents permissions for a role on a specific queue
+type QueuePermission struct {
+	QueueID    string
+	RoleID     string
+	CanSend    bool
+	CanReceive bool
+	CanPurge   bool
+	CanDelete  bool
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+// PermissionAction represents an action that can be performed on a queue
+type PermissionAction string
+
+const (
+	ActionSend    PermissionAction = "send"
+	ActionReceive PermissionAction = "receive"
+	ActionPurge   PermissionAction = "purge"
+	ActionDelete  PermissionAction = "delete"
+)
 
 // AuthStorage defines the interface for authentication-related storage operations
 type AuthStorage interface {
@@ -117,4 +139,10 @@ type AuthStorage interface {
 
 	// Audit log
 	LogAuthEvent(ctx context.Context, userID, eventType string, success bool, ipAddress, userAgent, metadata string) error
+
+	// Queue permission operations
+	GetQueuePermissions(ctx context.Context, queueID string, roleIDs []string) (*QueuePermission, error)
+	SetQueuePermissions(ctx context.Context, perm *QueuePermission) error
+	DeleteQueuePermissions(ctx context.Context, queueID, roleID string) error
+	GetRoleByName(ctx context.Context, roleName string) (*Role, error)
 }

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -55,7 +55,8 @@ type Config struct {
 	ProfilerEnabled bool
 
 	// Authentication settings
-	AuthEnabled   bool
-	AuthJWTSecret string
-	AuthIssuer    string
+	AuthEnabled      bool
+	AuthJWTSecret    string
+	AuthIssuer       string
+	AuthOAuthBaseURL string // Base URL for OAuth callbacks (e.g., "https://example.com")
 }

--- a/internal/server/grpc_transport.go
+++ b/internal/server/grpc_transport.go
@@ -3,8 +3,12 @@ package server
 import (
 	"context"
 
+	"github.com/plainq/plainq/internal/server/auth"
+	"github.com/plainq/plainq/internal/server/interceptor"
 	v1 "github.com/plainq/plainq/internal/server/schema/v1"
 	"github.com/plainq/servekit/respond"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func (s *PlainQ) ListQueues(
@@ -36,6 +40,14 @@ func (s *PlainQ) DescribeQueue(
 }
 
 func (s *PlainQ) CreateQueue(ctx context.Context, r *v1.CreateQueueRequest) (*v1.CreateQueueResponse, error) {
+	// Queue creation requires admin role.
+	if s.permissionService != nil {
+		claims, ok := interceptor.GetClaimsFromContext(ctx)
+		if !ok || !auth.IsAdmin(claims.Roles) {
+			return nil, status.Error(codes.PermissionDenied, "admin role required to create queues")
+		}
+	}
+
 	output, createErr := s.storage.CreateQueue(ctx, r)
 	if createErr != nil {
 		return respond.ErrorGRPC[*v1.CreateQueueResponse](ctx, createErr)
@@ -49,6 +61,17 @@ func (s *PlainQ) DeleteQueue(ctx context.Context, r *v1.DeleteQueueRequest) (*v1
 		return respond.ErrorGRPC[*v1.DeleteQueueResponse](ctx, err)
 	}
 
+	// Check delete permission.
+	if s.permissionService != nil {
+		claims, ok := interceptor.GetClaimsFromContext(ctx)
+		if !ok {
+			return nil, status.Error(codes.Unauthenticated, "authentication required")
+		}
+		if err := s.permissionService.CheckQueuePermission(ctx, r.QueueId, claims.Roles, auth.ActionDelete); err != nil {
+			return nil, status.Error(codes.PermissionDenied, err.Error())
+		}
+	}
+
 	if _, err := s.storage.DeleteQueue(ctx, r); err != nil {
 		return respond.ErrorGRPC[*v1.DeleteQueueResponse](ctx, err)
 	}
@@ -59,6 +82,17 @@ func (s *PlainQ) DeleteQueue(ctx context.Context, r *v1.DeleteQueueRequest) (*v1
 func (s *PlainQ) PurgeQueue(ctx context.Context, r *v1.PurgeQueueRequest) (*v1.PurgeQueueResponse, error) {
 	if err := validateQueueIDFromRequest(r); err != nil {
 		return respond.ErrorGRPC[*v1.PurgeQueueResponse](ctx, err)
+	}
+
+	// Check purge permission.
+	if s.permissionService != nil {
+		claims, ok := interceptor.GetClaimsFromContext(ctx)
+		if !ok {
+			return nil, status.Error(codes.Unauthenticated, "authentication required")
+		}
+		if err := s.permissionService.CheckQueuePermission(ctx, r.QueueId, claims.Roles, auth.ActionPurge); err != nil {
+			return nil, status.Error(codes.PermissionDenied, err.Error())
+		}
 	}
 
 	output, purgeErr := s.storage.PurgeQueue(ctx, r)
@@ -74,6 +108,17 @@ func (s *PlainQ) Send(ctx context.Context, r *v1.SendRequest) (*v1.SendResponse,
 		return respond.ErrorGRPC[*v1.SendResponse](ctx, err)
 	}
 
+	// Check send permission.
+	if s.permissionService != nil {
+		claims, ok := interceptor.GetClaimsFromContext(ctx)
+		if !ok {
+			return nil, status.Error(codes.Unauthenticated, "authentication required")
+		}
+		if err := s.permissionService.CheckQueuePermission(ctx, r.QueueId, claims.Roles, auth.ActionSend); err != nil {
+			return nil, status.Error(codes.PermissionDenied, err.Error())
+		}
+	}
+
 	output, sendErr := s.storage.Send(ctx, r)
 	if sendErr != nil {
 		return respond.ErrorGRPC[*v1.SendResponse](ctx, sendErr)
@@ -87,6 +132,17 @@ func (s *PlainQ) Receive(ctx context.Context, r *v1.ReceiveRequest) (*v1.Receive
 		return respond.ErrorGRPC[*v1.ReceiveResponse](ctx, err)
 	}
 
+	// Check receive permission.
+	if s.permissionService != nil {
+		claims, ok := interceptor.GetClaimsFromContext(ctx)
+		if !ok {
+			return nil, status.Error(codes.Unauthenticated, "authentication required")
+		}
+		if err := s.permissionService.CheckQueuePermission(ctx, r.QueueId, claims.Roles, auth.ActionReceive); err != nil {
+			return nil, status.Error(codes.PermissionDenied, err.Error())
+		}
+	}
+
 	output, receiveErr := s.storage.Receive(ctx, r)
 	if receiveErr != nil {
 		return respond.ErrorGRPC[*v1.ReceiveResponse](ctx, receiveErr)
@@ -98,6 +154,17 @@ func (s *PlainQ) Receive(ctx context.Context, r *v1.ReceiveRequest) (*v1.Receive
 func (s *PlainQ) Delete(ctx context.Context, r *v1.DeleteRequest) (*v1.DeleteResponse, error) {
 	if err := validateQueueIDFromRequest(r); err != nil {
 		return respond.ErrorGRPC[*v1.DeleteResponse](ctx, err)
+	}
+
+	// Check receive permission (delete message requires receive permission).
+	if s.permissionService != nil {
+		claims, ok := interceptor.GetClaimsFromContext(ctx)
+		if !ok {
+			return nil, status.Error(codes.Unauthenticated, "authentication required")
+		}
+		if err := s.permissionService.CheckQueuePermission(ctx, r.QueueId, claims.Roles, auth.ActionReceive); err != nil {
+			return nil, status.Error(codes.PermissionDenied, err.Error())
+		}
 	}
 
 	output, deleteErr := s.storage.Delete(ctx, r)

--- a/internal/server/storage/litestore/auth_storage.go
+++ b/internal/server/storage/litestore/auth_storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/plainq/plainq/internal/server/auth"
@@ -707,4 +708,114 @@ func (s *Storage) DeleteOAuthConnection(ctx context.Context, connectionID string
 	}
 
 	return nil
+}
+
+// Queue permission operations
+
+// GetQueuePermissions retrieves aggregated permissions for a queue across multiple roles.
+// Returns combined permissions (OR of all role permissions) for the given queue and roles.
+func (s *Storage) GetQueuePermissions(ctx context.Context, queueID string, roleIDs []string) (*auth.QueuePermission, error) {
+	if len(roleIDs) == 0 {
+		return &auth.QueuePermission{QueueID: queueID}, nil
+	}
+
+	// Build placeholders for IN clause
+	placeholders := make([]string, len(roleIDs))
+	args := make([]interface{}, len(roleIDs)+1)
+	args[0] = queueID
+	for i, roleID := range roleIDs {
+		placeholders[i] = "?"
+		args[i+1] = roleID
+	}
+
+	query := fmt.Sprintf(`
+		SELECT
+			MAX(can_send) as can_send,
+			MAX(can_receive) as can_receive,
+			MAX(can_purge) as can_purge,
+			MAX(can_delete) as can_delete
+		FROM queue_permissions
+		WHERE queue_id = ? AND role_id IN (%s)
+	`, strings.Join(placeholders, ","))
+
+	var canSend, canReceive, canPurge, canDelete sql.NullBool
+	err := s.db.QueryRowContext(ctx, query, args...).Scan(
+		&canSend, &canReceive, &canPurge, &canDelete,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return &auth.QueuePermission{QueueID: queueID}, nil
+		}
+		return nil, fmt.Errorf("failed to get queue permissions: %w", err)
+	}
+
+	return &auth.QueuePermission{
+		QueueID:    queueID,
+		CanSend:    canSend.Bool,
+		CanReceive: canReceive.Bool,
+		CanPurge:   canPurge.Bool,
+		CanDelete:  canDelete.Bool,
+	}, nil
+}
+
+// SetQueuePermissions creates or updates permissions for a role on a queue
+func (s *Storage) SetQueuePermissions(ctx context.Context, perm *auth.QueuePermission) error {
+	now := time.Now()
+
+	query := `
+		INSERT INTO queue_permissions (queue_id, role_id, can_send, can_receive, can_purge, can_delete, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT (queue_id, role_id) DO UPDATE SET
+			can_send = excluded.can_send,
+			can_receive = excluded.can_receive,
+			can_purge = excluded.can_purge,
+			can_delete = excluded.can_delete,
+			updated_at = excluded.updated_at
+	`
+
+	_, err := s.db.ExecContext(ctx, query,
+		perm.QueueID, perm.RoleID, perm.CanSend, perm.CanReceive, perm.CanPurge, perm.CanDelete, now, now,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to set queue permissions: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteQueuePermissions removes permissions for a role on a queue
+func (s *Storage) DeleteQueuePermissions(ctx context.Context, queueID, roleID string) error {
+	query := `
+		DELETE FROM queue_permissions
+		WHERE queue_id = ? AND role_id = ?
+	`
+
+	_, err := s.db.ExecContext(ctx, query, queueID, roleID)
+	if err != nil {
+		return fmt.Errorf("failed to delete queue permissions: %w", err)
+	}
+
+	return nil
+}
+
+// GetRoleByName retrieves a role by its name
+func (s *Storage) GetRoleByName(ctx context.Context, roleName string) (*auth.Role, error) {
+	query := `
+		SELECT role_id, role_name, created_at
+		FROM roles
+		WHERE role_name = ?
+	`
+
+	var role auth.Role
+	err := s.db.QueryRowContext(ctx, query, roleName).Scan(
+		&role.RoleID, &role.RoleName, &role.CreatedAt,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("role not found")
+		}
+		return nil, fmt.Errorf("failed to get role: %w", err)
+	}
+
+	return &role, nil
 }

--- a/internal/server/storage/litestore/auth_storage.go
+++ b/internal/server/storage/litestore/auth_storage.go
@@ -710,7 +710,7 @@ func (s *Storage) DeleteOAuthConnection(ctx context.Context, connectionID string
 	return nil
 }
 
-// Queue permission operations
+// Queue permission operations.
 
 // GetQueuePermissions retrieves aggregated permissions for a queue across multiple roles.
 // Returns combined permissions (OR of all role permissions) for the given queue and roles.
@@ -758,7 +758,7 @@ func (s *Storage) GetQueuePermissions(ctx context.Context, queueID string, roleI
 	}, nil
 }
 
-// SetQueuePermissions creates or updates permissions for a role on a queue
+// SetQueuePermissions creates or updates permissions for a role on a queue.
 func (s *Storage) SetQueuePermissions(ctx context.Context, perm *auth.QueuePermission) error {
 	now := time.Now()
 
@@ -783,7 +783,7 @@ func (s *Storage) SetQueuePermissions(ctx context.Context, perm *auth.QueuePermi
 	return nil
 }
 
-// DeleteQueuePermissions removes permissions for a role on a queue
+// DeleteQueuePermissions removes permissions for a role on a queue.
 func (s *Storage) DeleteQueuePermissions(ctx context.Context, queueID, roleID string) error {
 	query := `
 		DELETE FROM queue_permissions
@@ -798,7 +798,7 @@ func (s *Storage) DeleteQueuePermissions(ctx context.Context, queueID, roleID st
 	return nil
 }
 
-// GetRoleByName retrieves a role by its name
+// GetRoleByName retrieves a role by its name.
 func (s *Storage) GetRoleByName(ctx context.Context, roleName string) (*auth.Role, error) {
 	query := `
 		SELECT role_id, role_name, created_at


### PR DESCRIPTION
This commit completes the RBAC (Role-Based Access Control) implementation
and integrates OAuth provider support:

RBAC Implementation:
- Add gRPC auth interceptor registration to protect gRPC endpoints
- Implement queue permission enforcement service with role-based checks
- Add permission checking for queue operations (send, receive, purge, delete)
- Admin role has full access to all queues
- Non-admin users require specific queue permissions via queue_permissions table

OAuth Integration:
- Add OAuth callback handler and routes (/api/v1/auth/oauth/{provider}/callback)
- Add OAuth init endpoint to get authorization URL
- Add OAuth providers listing endpoint for UI (/api/v1/auth/oauth/providers)
- Make OAuth redirect URL configurable via --auth.oauth-base-url flag
- Support OAuth provider state parameter for CSRF protection

Storage:
- Add queue permission storage methods (GetQueuePermissions, SetQueuePermissions)
- Add GetRoleByName method for role lookup
- Permission queries aggregate across multiple roles using MAX

Configuration:
- Add AuthOAuthBaseURL config option for customizing OAuth callback URLs
- Default base URL: http://localhost:8081

https://claude.ai/code/session_01BPqmnpccQTdKqUsYL4Y7gP