### PR TITLE
feat: Implement comprehensive queue telemetry and metrics dashboard

### DIFF
--- a/internal/houston/ui/src/components/metrics/InFlightChart.jsx
+++ b/internal/houston/ui/src/components/metrics/InFlightChart.jsx
@@ -1,0 +1,193 @@
+import { useState, useEffect } from "react";
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceLine,
+} from "recharts";
+
+export default function InFlightChart({ queueId, timeRange, height = 300 }) {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [threshold, setThreshold] = useState(100);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const endpoint = queueId
+          ? `/api/v1/metrics/queue/${queueId}/inflight?range=${timeRange}`
+          : `/api/v1/metrics/inflight?range=${timeRange}`;
+
+        const response = await fetch(endpoint);
+        if (response.ok) {
+          const result = await response.json();
+
+          // Transform data
+          const transformedData = (result.history || []).map((point) => ({
+            timestamp: point.timestamp,
+            value: point.value,
+          }));
+          setData(transformedData);
+        }
+      } catch (error) {
+        console.error("Failed to fetch in-flight data:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+
+    const interval = setInterval(fetchData, 5000);
+    return () => clearInterval(interval);
+  }, [queueId, timeRange]);
+
+  const formatTimestamp = (timestamp) => {
+    const date = new Date(timestamp);
+    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  };
+
+  const formatValue = (value) => {
+    if (value >= 1000) return `${(value / 1000).toFixed(1)}K`;
+    return value.toString();
+  };
+
+  const CustomTooltip = ({ active, payload, label }) => {
+    if (active && payload && payload.length) {
+      const value = payload[0].value;
+      const isHigh = value > threshold;
+
+      return (
+        <div className="bg-white border border-gray-200 rounded-lg shadow-lg p-3">
+          <p className="text-sm text-gray-500 mb-2">
+            {new Date(label).toLocaleString()}
+          </p>
+          <div className="flex items-center gap-2">
+            <div
+              className={`w-3 h-3 rounded-full ${
+                isHigh ? "bg-orange-500" : "bg-blue-500"
+              }`}
+            />
+            <span className="text-sm font-medium">In Flight:</span>
+            <span className={`text-sm font-bold ${isHigh ? "text-orange-600" : ""}`}>
+              {formatValue(value)} messages
+            </span>
+          </div>
+          {isHigh && (
+            <p className="text-xs text-orange-600 mt-2">
+              Above threshold ({threshold})
+            </p>
+          )}
+        </div>
+      );
+    }
+    return null;
+  };
+
+  // Calculate max value and stats
+  const maxValue = data.length > 0 ? Math.max(...data.map((d) => d.value)) : 0;
+  const avgValue =
+    data.length > 0
+      ? data.reduce((sum, d) => sum + d.value, 0) / data.length
+      : 0;
+  const currentValue = data.length > 0 ? data[data.length - 1].value : 0;
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center" style={{ height }}>
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div>
+      </div>
+    );
+  }
+
+  if (data.length === 0) {
+    return (
+      <div className="flex items-center justify-center text-gray-500" style={{ height }}>
+        No data available for the selected time range
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {/* Stats row */}
+      <div className="flex gap-6 mb-4">
+        <div className="text-center">
+          <p className="text-sm text-gray-500">Current</p>
+          <p className="text-xl font-bold text-blue-600">
+            {formatValue(currentValue)}
+          </p>
+        </div>
+        <div className="text-center">
+          <p className="text-sm text-gray-500">Average</p>
+          <p className="text-xl font-bold text-gray-700">
+            {formatValue(Math.round(avgValue))}
+          </p>
+        </div>
+        <div className="text-center">
+          <p className="text-sm text-gray-500">Peak</p>
+          <p className="text-xl font-bold text-orange-600">
+            {formatValue(maxValue)}
+          </p>
+        </div>
+        <div className="ml-auto">
+          <label className="text-sm text-gray-500 mr-2">Threshold:</label>
+          <input
+            type="number"
+            value={threshold}
+            onChange={(e) => setThreshold(parseInt(e.target.value) || 100)}
+            className="w-20 px-2 py-1 border rounded text-sm"
+          />
+        </div>
+      </div>
+
+      <ResponsiveContainer width="100%" height={height}>
+        <AreaChart data={data}>
+          <defs>
+            <linearGradient id="colorInFlight" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.3} />
+              <stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+          <XAxis
+            dataKey="timestamp"
+            tickFormatter={formatTimestamp}
+            stroke="#9ca3af"
+            fontSize={12}
+          />
+          <YAxis
+            tickFormatter={formatValue}
+            stroke="#9ca3af"
+            fontSize={12}
+            domain={[0, Math.max(maxValue, threshold) * 1.1]}
+          />
+          <Tooltip content={<CustomTooltip />} />
+          <ReferenceLine
+            y={threshold}
+            stroke="#f97316"
+            strokeDasharray="5 5"
+            label={{
+              value: `Threshold (${threshold})`,
+              fill: "#f97316",
+              fontSize: 12,
+            }}
+          />
+          <Area
+            type="monotone"
+            dataKey="value"
+            name="In Flight"
+            stroke="#3b82f6"
+            strokeWidth={2}
+            fillOpacity={1}
+            fill="url(#colorInFlight)"
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/internal/houston/ui/src/components/metrics/MetricCard.jsx
+++ b/internal/houston/ui/src/components/metrics/MetricCard.jsx
@@ -1,0 +1,134 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ArrowUp, ArrowDown, Minus, AlertTriangle } from "lucide-react";
+
+const COLORS = {
+  blue: {
+    bg: "bg-blue-50",
+    text: "text-blue-600",
+    border: "border-blue-200",
+  },
+  green: {
+    bg: "bg-green-50",
+    text: "text-green-600",
+    border: "border-green-200",
+  },
+  purple: {
+    bg: "bg-purple-50",
+    text: "text-purple-600",
+    border: "border-purple-200",
+  },
+  orange: {
+    bg: "bg-orange-50",
+    text: "text-orange-600",
+    border: "border-orange-200",
+  },
+  red: {
+    bg: "bg-red-50",
+    text: "text-red-600",
+    border: "border-red-200",
+  },
+};
+
+export default function MetricCard({
+  title,
+  value,
+  unit,
+  description,
+  trend = "neutral",
+  color = "blue",
+  previousValue,
+  sparklineData,
+}) {
+  const colorScheme = COLORS[color] || COLORS.blue;
+
+  const TrendIcon = () => {
+    switch (trend) {
+      case "up":
+        return <ArrowUp className="h-4 w-4 text-green-500" />;
+      case "down":
+        return <ArrowDown className="h-4 w-4 text-red-500" />;
+      case "warning":
+        return <AlertTriangle className="h-4 w-4 text-orange-500" />;
+      default:
+        return <Minus className="h-4 w-4 text-gray-400" />;
+    }
+  };
+
+  const calculateChange = () => {
+    if (previousValue === undefined || previousValue === 0) return null;
+    const change = ((parseFloat(value) - previousValue) / previousValue) * 100;
+    return change.toFixed(1);
+  };
+
+  const change = calculateChange();
+
+  return (
+    <Card className={`${colorScheme.bg} ${colorScheme.border} border`}>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium text-gray-600">
+          {title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-baseline gap-2">
+          <span className={`text-3xl font-bold ${colorScheme.text}`}>
+            {value}
+          </span>
+          <span className="text-sm text-gray-500">{unit}</span>
+          <div className="ml-auto flex items-center gap-1">
+            <TrendIcon />
+            {change && (
+              <span
+                className={`text-sm ${
+                  parseFloat(change) >= 0 ? "text-green-500" : "text-red-500"
+                }`}
+              >
+                {parseFloat(change) >= 0 ? "+" : ""}
+                {change}%
+              </span>
+            )}
+          </div>
+        </div>
+        {description && (
+          <p className="text-xs text-gray-500 mt-2">{description}</p>
+        )}
+        {sparklineData && sparklineData.length > 0 && (
+          <div className="mt-3">
+            <MiniSparkline data={sparklineData} color={colorScheme.text} />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// Mini sparkline component
+function MiniSparkline({ data, color, height = 30 }) {
+  if (!data || data.length < 2) return null;
+
+  const values = data.map((d) => d.value || d);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+
+  const width = 100;
+  const points = values
+    .map((value, index) => {
+      const x = (index / (values.length - 1)) * width;
+      const y = height - ((value - min) / range) * height;
+      return `${x},${y}`;
+    })
+    .join(" ");
+
+  return (
+    <svg width="100%" height={height} viewBox={`0 0 ${width} ${height}`}>
+      <polyline
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        points={points}
+        className={color}
+      />
+    </svg>
+  );
+}

--- a/internal/houston/ui/src/components/metrics/MetricsDashboard.jsx
+++ b/internal/houston/ui/src/components/metrics/MetricsDashboard.jsx
@@ -1,0 +1,259 @@
+import { useState, useEffect, useCallback } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { RefreshCw } from "lucide-react";
+import RateChart from "./RateChart";
+import MetricCard from "./MetricCard";
+import QueueMetricsTable from "./QueueMetricsTable";
+import InFlightChart from "./InFlightChart";
+
+const TIME_RANGE_PRESETS = [
+  { value: "5m", label: "Last 5 minutes" },
+  { value: "15m", label: "Last 15 minutes" },
+  { value: "30m", label: "Last 30 minutes" },
+  { value: "1h", label: "Last 1 hour" },
+  { value: "3h", label: "Last 3 hours" },
+  { value: "6h", label: "Last 6 hours" },
+  { value: "12h", label: "Last 12 hours" },
+  { value: "24h", label: "Last 24 hours" },
+  { value: "7d", label: "Last 7 days" },
+  { value: "30d", label: "Last 30 days" },
+];
+
+export default function MetricsDashboard({ queueId }) {
+  const [timeRange, setTimeRange] = useState("1h");
+  const [overview, setOverview] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [autoRefresh, setAutoRefresh] = useState(true);
+  const [lastUpdated, setLastUpdated] = useState(null);
+
+  const fetchOverview = useCallback(async () => {
+    try {
+      const response = await fetch(`/api/v1/metrics/overview`);
+      if (response.ok) {
+        const data = await response.json();
+        setOverview(data);
+        setLastUpdated(new Date());
+      }
+    } catch (error) {
+      console.error("Failed to fetch metrics overview:", error);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchOverview();
+
+    if (autoRefresh) {
+      const interval = setInterval(fetchOverview, 5000); // Refresh every 5 seconds
+      return () => clearInterval(interval);
+    }
+  }, [fetchOverview, autoRefresh]);
+
+  const formatRate = (rate) => {
+    if (rate === undefined || rate === null) return "0";
+    if (rate >= 1000000) return `${(rate / 1000000).toFixed(2)}M`;
+    if (rate >= 1000) return `${(rate / 1000).toFixed(2)}K`;
+    return rate.toFixed(2);
+  };
+
+  const formatNumber = (num) => {
+    if (num === undefined || num === null) return "0";
+    if (num >= 1000000000) return `${(num / 1000000000).toFixed(2)}B`;
+    if (num >= 1000000) return `${(num / 1000000).toFixed(2)}M`;
+    if (num >= 1000) return `${(num / 1000).toFixed(2)}K`;
+    return num.toString();
+  };
+
+  if (loading && !overview) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div>
+      </div>
+    );
+  }
+
+  const systemMetrics = overview?.systemMetrics || {};
+  const queueMetrics = overview?.queueMetrics || [];
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex justify-between items-center">
+        <div>
+          <h2 className="text-2xl font-bold">Metrics Dashboard</h2>
+          <p className="text-gray-500 text-sm">
+            {lastUpdated && `Last updated: ${lastUpdated.toLocaleTimeString()}`}
+          </p>
+        </div>
+        <div className="flex items-center gap-4">
+          <Select value={timeRange} onValueChange={setTimeRange}>
+            <SelectTrigger className="w-[180px]">
+              <SelectValue placeholder="Select time range" />
+            </SelectTrigger>
+            <SelectContent>
+              {TIME_RANGE_PRESETS.map((preset) => (
+                <SelectItem key={preset.value} value={preset.value}>
+                  {preset.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={fetchOverview}
+            className={autoRefresh ? "animate-spin-slow" : ""}
+          >
+            <RefreshCw className="h-4 w-4" />
+          </Button>
+          <Button
+            variant={autoRefresh ? "default" : "outline"}
+            onClick={() => setAutoRefresh(!autoRefresh)}
+          >
+            {autoRefresh ? "Auto-refresh ON" : "Auto-refresh OFF"}
+          </Button>
+        </div>
+      </div>
+
+      {/* System-wide metrics cards */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        <MetricCard
+          title="Send Rate"
+          value={formatRate(systemMetrics.sendRate)}
+          unit="msg/s"
+          description="Messages sent per second"
+          trend={systemMetrics.sendRate > 0 ? "up" : "neutral"}
+          color="blue"
+        />
+        <MetricCard
+          title="Receive Rate"
+          value={formatRate(systemMetrics.receiveRate)}
+          unit="msg/s"
+          description="Messages received per second"
+          trend={systemMetrics.receiveRate > 0 ? "up" : "neutral"}
+          color="green"
+        />
+        <MetricCard
+          title="Delete Rate"
+          value={formatRate(systemMetrics.deleteRate)}
+          unit="msg/s"
+          description="Messages deleted per second"
+          trend={systemMetrics.deleteRate > 0 ? "up" : "neutral"}
+          color="purple"
+        />
+        <MetricCard
+          title="In Flight"
+          value={formatNumber(systemMetrics.totalInFlight)}
+          unit="msgs"
+          description="Messages currently being processed"
+          trend={systemMetrics.totalInFlight > 100 ? "warning" : "neutral"}
+          color="orange"
+        />
+      </div>
+
+      {/* Charts */}
+      <Tabs defaultValue="rates" className="space-y-4">
+        <TabsList>
+          <TabsTrigger value="rates">Throughput Rates</TabsTrigger>
+          <TabsTrigger value="inflight">In-Flight Messages</TabsTrigger>
+          <TabsTrigger value="queues">Queue Details</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="rates" className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>Message Throughput</CardTitle>
+              <CardDescription>
+                Send, receive, and delete rates over time
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <RateChart
+                queueId={queueId}
+                timeRange={timeRange}
+                height={400}
+              />
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="inflight" className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>In-Flight Messages</CardTitle>
+              <CardDescription>
+                Messages currently being processed across all queues
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <InFlightChart
+                queueId={queueId}
+                timeRange={timeRange}
+                height={400}
+              />
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="queues" className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>Queue Metrics</CardTitle>
+              <CardDescription>
+                Detailed metrics for each queue
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <QueueMetricsTable queues={queueMetrics} />
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+
+      {/* Summary stats */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-gray-500">
+              Total Messages Sent
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-3xl font-bold">
+              {formatNumber(systemMetrics.totalSent)}
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-gray-500">
+              Total Messages Received
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-3xl font-bold">
+              {formatNumber(systemMetrics.totalReceived)}
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-gray-500">
+              Total Messages Deleted
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-3xl font-bold">
+              {formatNumber(systemMetrics.totalDeleted)}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/internal/houston/ui/src/components/metrics/QueueDetailMetrics.jsx
+++ b/internal/houston/ui/src/components/metrics/QueueDetailMetrics.jsx
@@ -1,0 +1,284 @@
+import { useState, useEffect, useCallback } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
+import { RefreshCw, Download, Activity, Clock, Zap, AlertCircle } from "lucide-react";
+import RateChart from "./RateChart";
+import InFlightChart from "./InFlightChart";
+import MetricCard from "./MetricCard";
+
+const TIME_RANGE_PRESETS = [
+  { value: "5m", label: "Last 5 minutes" },
+  { value: "15m", label: "Last 15 minutes" },
+  { value: "30m", label: "Last 30 minutes" },
+  { value: "1h", label: "Last 1 hour" },
+  { value: "3h", label: "Last 3 hours" },
+  { value: "6h", label: "Last 6 hours" },
+  { value: "12h", label: "Last 12 hours" },
+  { value: "24h", label: "Last 24 hours" },
+  { value: "7d", label: "Last 7 days" },
+];
+
+export default function QueueDetailMetrics({ queueId, queueName }) {
+  const [timeRange, setTimeRange] = useState("1h");
+  const [metrics, setMetrics] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [autoRefresh, setAutoRefresh] = useState(true);
+
+  const fetchMetrics = useCallback(async () => {
+    try {
+      const response = await fetch(
+        `/api/v1/metrics/queue/${queueId}?range=${timeRange}`
+      );
+      if (response.ok) {
+        const data = await response.json();
+        setMetrics(data);
+      }
+    } catch (error) {
+      console.error("Failed to fetch queue metrics:", error);
+    } finally {
+      setLoading(false);
+    }
+  }, [queueId, timeRange]);
+
+  useEffect(() => {
+    fetchMetrics();
+
+    if (autoRefresh) {
+      const interval = setInterval(fetchMetrics, 5000);
+      return () => clearInterval(interval);
+    }
+  }, [fetchMetrics, autoRefresh]);
+
+  const formatRate = (rate) => {
+    if (rate === undefined || rate === null) return "0";
+    if (rate >= 1000) return `${(rate / 1000).toFixed(2)}K`;
+    return rate.toFixed(2);
+  };
+
+  const formatNumber = (num) => {
+    if (num === undefined || num === null) return "0";
+    if (num >= 1000000) return `${(num / 1000000).toFixed(2)}M`;
+    if (num >= 1000) return `${(num / 1000).toFixed(2)}K`;
+    return num.toString();
+  };
+
+  const handleExport = async (format) => {
+    try {
+      const response = await fetch(
+        `/api/v1/metrics/export?queue_id=${queueId}&range=${timeRange}&format=${format}`
+      );
+      if (response.ok) {
+        const blob = await response.blob();
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = `metrics-${queueId}-${timeRange}.${format}`;
+        a.click();
+        window.URL.revokeObjectURL(url);
+      }
+    } catch (error) {
+      console.error("Export failed:", error);
+    }
+  };
+
+  if (loading && !metrics) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex justify-between items-center">
+        <div>
+          <h3 className="text-xl font-bold">Queue Metrics</h3>
+          <p className="text-sm text-gray-500">{queueName || queueId}</p>
+        </div>
+        <div className="flex items-center gap-4">
+          <Select value={timeRange} onValueChange={setTimeRange}>
+            <SelectTrigger className="w-[180px]">
+              <SelectValue placeholder="Select time range" />
+            </SelectTrigger>
+            <SelectContent>
+              {TIME_RANGE_PRESETS.map((preset) => (
+                <SelectItem key={preset.value} value={preset.value}>
+                  {preset.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button variant="outline" onClick={() => handleExport("json")}>
+            <Download className="h-4 w-4 mr-2" />
+            Export
+          </Button>
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={fetchMetrics}
+          >
+            <RefreshCw className="h-4 w-4" />
+          </Button>
+          <Button
+            variant={autoRefresh ? "default" : "outline"}
+            onClick={() => setAutoRefresh(!autoRefresh)}
+            size="sm"
+          >
+            {autoRefresh ? "Auto ON" : "Auto OFF"}
+          </Button>
+        </div>
+      </div>
+
+      {/* Current metrics cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <MetricCard
+          title="Current Send Rate"
+          value={formatRate(metrics?.currentSendRate)}
+          unit="msg/s"
+          description="Messages being sent now"
+          color="blue"
+        />
+        <MetricCard
+          title="Current Receive Rate"
+          value={formatRate(metrics?.currentReceiveRate)}
+          unit="msg/s"
+          description="Messages being received now"
+          color="green"
+        />
+        <MetricCard
+          title="Current Delete Rate"
+          value={formatRate(metrics?.currentDeleteRate)}
+          unit="msg/s"
+          description="Messages being deleted now"
+          color="purple"
+        />
+        <MetricCard
+          title="In Flight"
+          value={formatNumber(metrics?.currentInFlight)}
+          unit="msgs"
+          description="Being processed"
+          color="orange"
+          trend={metrics?.currentInFlight > 100 ? "warning" : "neutral"}
+        />
+      </div>
+
+      {/* Summary stats */}
+      <div className="grid grid-cols-2 md:grid-cols-6 gap-4">
+        <Card>
+          <CardContent className="pt-4">
+            <div className="flex items-center gap-2">
+              <Activity className="h-4 w-4 text-gray-500" />
+              <div>
+                <p className="text-xs text-gray-500">Avg Send Rate</p>
+                <p className="font-bold">{formatRate(metrics?.avgSendRate)}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-4">
+            <div className="flex items-center gap-2">
+              <Zap className="h-4 w-4 text-gray-500" />
+              <div>
+                <p className="text-xs text-gray-500">Max Send Rate</p>
+                <p className="font-bold">{formatRate(metrics?.maxSendRate)}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-4">
+            <div className="flex items-center gap-2">
+              <Activity className="h-4 w-4 text-gray-500" />
+              <div>
+                <p className="text-xs text-gray-500">Avg Receive Rate</p>
+                <p className="font-bold">{formatRate(metrics?.avgReceiveRate)}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-4">
+            <div className="flex items-center gap-2">
+              <Zap className="h-4 w-4 text-gray-500" />
+              <div>
+                <p className="text-xs text-gray-500">Max Receive Rate</p>
+                <p className="font-bold">{formatRate(metrics?.maxReceiveRate)}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-4">
+            <div className="flex items-center gap-2">
+              <Clock className="h-4 w-4 text-gray-500" />
+              <div>
+                <p className="text-xs text-gray-500">Total Sent</p>
+                <p className="font-bold">{formatNumber(metrics?.totalSent)}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-4">
+            <div className="flex items-center gap-2">
+              <AlertCircle className="h-4 w-4 text-gray-500" />
+              <div>
+                <p className="text-xs text-gray-500">Total Deleted</p>
+                <p className="font-bold">{formatNumber(metrics?.totalDeleted)}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Charts */}
+      <Tabs defaultValue="rates" className="space-y-4">
+        <TabsList>
+          <TabsTrigger value="rates">Throughput</TabsTrigger>
+          <TabsTrigger value="inflight">In-Flight</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="rates">
+          <Card>
+            <CardHeader>
+              <CardTitle>Message Throughput</CardTitle>
+              <CardDescription>
+                Send, receive, and delete rates over time
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <RateChart
+                queueId={queueId}
+                timeRange={timeRange}
+                height={350}
+              />
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="inflight">
+          <Card>
+            <CardHeader>
+              <CardTitle>In-Flight Messages</CardTitle>
+              <CardDescription>
+                Messages currently being processed
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <InFlightChart
+                queueId={queueId}
+                timeRange={timeRange}
+                height={350}
+              />
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/internal/houston/ui/src/components/metrics/QueueMetricsTable.jsx
+++ b/internal/houston/ui/src/components/metrics/QueueMetricsTable.jsx
@@ -1,0 +1,241 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ArrowUpDown, ChevronRight, TrendingUp, TrendingDown, Minus } from "lucide-react";
+import { useState } from "react";
+
+export default function QueueMetricsTable({ queues }) {
+  const [sortField, setSortField] = useState("queueId");
+  const [sortDirection, setSortDirection] = useState("asc");
+
+  const formatRate = (rate) => {
+    if (rate === undefined || rate === null) return "0";
+    if (rate >= 1000) return `${(rate / 1000).toFixed(2)}K`;
+    return rate.toFixed(2);
+  };
+
+  const formatNumber = (num) => {
+    if (num === undefined || num === null) return "0";
+    if (num >= 1000000) return `${(num / 1000000).toFixed(2)}M`;
+    if (num >= 1000) return `${(num / 1000).toFixed(2)}K`;
+    return num.toString();
+  };
+
+  const handleSort = (field) => {
+    if (sortField === field) {
+      setSortDirection(sortDirection === "asc" ? "desc" : "asc");
+    } else {
+      setSortField(field);
+      setSortDirection("asc");
+    }
+  };
+
+  const sortedQueues = [...queues].sort((a, b) => {
+    let aVal = a[sortField];
+    let bVal = b[sortField];
+
+    // Handle string vs number comparison
+    if (typeof aVal === "string") {
+      aVal = aVal.toLowerCase();
+      bVal = bVal.toLowerCase();
+    }
+
+    if (sortDirection === "asc") {
+      return aVal > bVal ? 1 : -1;
+    } else {
+      return aVal < bVal ? 1 : -1;
+    }
+  });
+
+  const getHealthStatus = (queue) => {
+    // Simple health check based on metrics
+    if (queue.inFlight > 1000) return { status: "warning", label: "High Load" };
+    if (queue.emptyReceives > queue.messagesReceived * 0.5)
+      return { status: "warning", label: "Many Empty Receives" };
+    if (queue.sendRate === 0 && queue.receiveRate === 0)
+      return { status: "idle", label: "Idle" };
+    return { status: "healthy", label: "Healthy" };
+  };
+
+  const StatusBadge = ({ status, label }) => {
+    const variants = {
+      healthy: "bg-green-100 text-green-700 border-green-200",
+      warning: "bg-orange-100 text-orange-700 border-orange-200",
+      idle: "bg-gray-100 text-gray-700 border-gray-200",
+      error: "bg-red-100 text-red-700 border-red-200",
+    };
+
+    return (
+      <Badge variant="outline" className={variants[status]}>
+        {label}
+      </Badge>
+    );
+  };
+
+  const RateTrend = ({ current, previous }) => {
+    if (previous === undefined || previous === 0) {
+      return <Minus className="h-4 w-4 text-gray-400" />;
+    }
+
+    const change = ((current - previous) / previous) * 100;
+
+    if (change > 10) {
+      return <TrendingUp className="h-4 w-4 text-green-500" />;
+    } else if (change < -10) {
+      return <TrendingDown className="h-4 w-4 text-red-500" />;
+    }
+    return <Minus className="h-4 w-4 text-gray-400" />;
+  };
+
+  const SortableHeader = ({ field, children }) => (
+    <TableHead
+      className="cursor-pointer hover:bg-gray-50"
+      onClick={() => handleSort(field)}
+    >
+      <div className="flex items-center gap-1">
+        {children}
+        <ArrowUpDown className="h-3 w-3 text-gray-400" />
+      </div>
+    </TableHead>
+  );
+
+  if (!queues || queues.length === 0) {
+    return (
+      <div className="text-center py-8 text-gray-500">
+        No queue metrics available
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <SortableHeader field="queueId">Queue ID</SortableHeader>
+            <TableHead>Status</TableHead>
+            <SortableHeader field="sendRate">Send Rate</SortableHeader>
+            <SortableHeader field="receiveRate">Receive Rate</SortableHeader>
+            <SortableHeader field="deleteRate">Delete Rate</SortableHeader>
+            <SortableHeader field="inFlight">In Flight</SortableHeader>
+            <SortableHeader field="messagesSent">Total Sent</SortableHeader>
+            <SortableHeader field="messagesReceived">Total Received</SortableHeader>
+            <TableHead></TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {sortedQueues.map((queue) => {
+            const health = getHealthStatus(queue);
+
+            return (
+              <TableRow key={queue.queueId} className="hover:bg-gray-50">
+                <TableCell className="font-medium">
+                  <a
+                    href={`/queue/${queue.queueId}`}
+                    className="text-blue-600 hover:underline"
+                  >
+                    {queue.queueName || queue.queueId}
+                  </a>
+                </TableCell>
+                <TableCell>
+                  <StatusBadge status={health.status} label={health.label} />
+                </TableCell>
+                <TableCell>
+                  <div className="flex items-center gap-2">
+                    <span className="font-mono">
+                      {formatRate(queue.sendRate)}
+                    </span>
+                    <span className="text-xs text-gray-500">msg/s</span>
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <div className="flex items-center gap-2">
+                    <span className="font-mono">
+                      {formatRate(queue.receiveRate)}
+                    </span>
+                    <span className="text-xs text-gray-500">msg/s</span>
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <div className="flex items-center gap-2">
+                    <span className="font-mono">
+                      {formatRate(queue.deleteRate)}
+                    </span>
+                    <span className="text-xs text-gray-500">msg/s</span>
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <span
+                    className={`font-mono ${
+                      queue.inFlight > 100 ? "text-orange-600 font-bold" : ""
+                    }`}
+                  >
+                    {formatNumber(queue.inFlight)}
+                  </span>
+                </TableCell>
+                <TableCell>
+                  <span className="font-mono">
+                    {formatNumber(queue.messagesSent)}
+                  </span>
+                </TableCell>
+                <TableCell>
+                  <span className="font-mono">
+                    {formatNumber(queue.messagesReceived)}
+                  </span>
+                </TableCell>
+                <TableCell>
+                  <Button variant="ghost" size="sm" asChild>
+                    <a href={`/queue/${queue.queueId}#metrics`}>
+                      <ChevronRight className="h-4 w-4" />
+                    </a>
+                  </Button>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+
+      {/* Summary row */}
+      <div className="mt-4 p-4 bg-gray-50 rounded-lg">
+        <div className="grid grid-cols-4 gap-4 text-sm">
+          <div>
+            <span className="text-gray-500">Total Queues:</span>
+            <span className="ml-2 font-bold">{queues.length}</span>
+          </div>
+          <div>
+            <span className="text-gray-500">Avg Send Rate:</span>
+            <span className="ml-2 font-bold">
+              {formatRate(
+                queues.reduce((sum, q) => sum + (q.sendRate || 0), 0) /
+                  queues.length
+              )}
+            </span>
+            <span className="text-xs text-gray-500 ml-1">msg/s</span>
+          </div>
+          <div>
+            <span className="text-gray-500">Total In Flight:</span>
+            <span className="ml-2 font-bold">
+              {formatNumber(queues.reduce((sum, q) => sum + (q.inFlight || 0), 0))}
+            </span>
+          </div>
+          <div>
+            <span className="text-gray-500">Total Messages:</span>
+            <span className="ml-2 font-bold">
+              {formatNumber(
+                queues.reduce((sum, q) => sum + (q.messagesSent || 0), 0)
+              )}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/internal/houston/ui/src/components/metrics/RateChart.jsx
+++ b/internal/houston/ui/src/components/metrics/RateChart.jsx
@@ -1,0 +1,239 @@
+import { useState, useEffect, useMemo } from "react";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  Area,
+  AreaChart,
+} from "recharts";
+
+const COLORS = {
+  send: "#3b82f6",    // Blue
+  receive: "#22c55e", // Green
+  delete: "#a855f7",  // Purple
+};
+
+export default function RateChart({ queueId, timeRange, height = 300 }) {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [chartType, setChartType] = useState("line");
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const endpoint = queueId
+          ? `/api/v1/metrics/queue/${queueId}/rates?range=${timeRange}`
+          : `/api/v1/metrics/rates?range=${timeRange}`;
+
+        const response = await fetch(endpoint);
+        if (response.ok) {
+          const result = await response.json();
+
+          // Transform data for Recharts
+          const transformedData = transformRateData(result.metrics);
+          setData(transformedData);
+        }
+      } catch (error) {
+        console.error("Failed to fetch rate data:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+
+    // Refresh every 5 seconds
+    const interval = setInterval(fetchData, 5000);
+    return () => clearInterval(interval);
+  }, [queueId, timeRange]);
+
+  // Transform API response to Recharts format
+  const transformRateData = (metrics) => {
+    if (!metrics || metrics.length === 0) return [];
+
+    // Create a map of timestamps to values
+    const dataMap = new Map();
+
+    metrics.forEach((metric) => {
+      const metricType = metric.metricName.replace("plainq_", "").replace("_rate", "");
+
+      (metric.dataPoints || []).forEach((point) => {
+        const timestamp = point.timestamp;
+        if (!dataMap.has(timestamp)) {
+          dataMap.set(timestamp, { timestamp });
+        }
+        dataMap.get(timestamp)[metricType] = point.value;
+      });
+    });
+
+    // Convert to array and sort by timestamp
+    return Array.from(dataMap.values()).sort((a, b) => a.timestamp - b.timestamp);
+  };
+
+  const formatTimestamp = (timestamp) => {
+    const date = new Date(timestamp);
+    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+  };
+
+  const formatValue = (value) => {
+    if (value === undefined || value === null) return "0";
+    if (value >= 1000) return `${(value / 1000).toFixed(1)}K`;
+    return value.toFixed(2);
+  };
+
+  const CustomTooltip = ({ active, payload, label }) => {
+    if (active && payload && payload.length) {
+      return (
+        <div className="bg-white border border-gray-200 rounded-lg shadow-lg p-3">
+          <p className="text-sm text-gray-500 mb-2">
+            {new Date(label).toLocaleString()}
+          </p>
+          {payload.map((entry, index) => (
+            <div key={index} className="flex items-center gap-2">
+              <div
+                className="w-3 h-3 rounded-full"
+                style={{ backgroundColor: entry.color }}
+              />
+              <span className="text-sm font-medium capitalize">
+                {entry.dataKey}:
+              </span>
+              <span className="text-sm">{formatValue(entry.value)} msg/s</span>
+            </div>
+          ))}
+        </div>
+      );
+    }
+    return null;
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center" style={{ height }}>
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div>
+      </div>
+    );
+  }
+
+  if (data.length === 0) {
+    return (
+      <div className="flex items-center justify-center text-gray-500" style={{ height }}>
+        No data available for the selected time range
+      </div>
+    );
+  }
+
+  const ChartComponent = chartType === "area" ? AreaChart : LineChart;
+
+  return (
+    <div>
+      <div className="flex justify-end mb-4 gap-2">
+        <button
+          onClick={() => setChartType("line")}
+          className={`px-3 py-1 text-sm rounded ${
+            chartType === "line"
+              ? "bg-gray-900 text-white"
+              : "bg-gray-100 text-gray-700"
+          }`}
+        >
+          Line
+        </button>
+        <button
+          onClick={() => setChartType("area")}
+          className={`px-3 py-1 text-sm rounded ${
+            chartType === "area"
+              ? "bg-gray-900 text-white"
+              : "bg-gray-100 text-gray-700"
+          }`}
+        >
+          Area
+        </button>
+      </div>
+
+      <ResponsiveContainer width="100%" height={height}>
+        <ChartComponent data={data}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+          <XAxis
+            dataKey="timestamp"
+            tickFormatter={formatTimestamp}
+            stroke="#9ca3af"
+            fontSize={12}
+          />
+          <YAxis
+            tickFormatter={formatValue}
+            stroke="#9ca3af"
+            fontSize={12}
+          />
+          <Tooltip content={<CustomTooltip />} />
+          <Legend />
+
+          {chartType === "area" ? (
+            <>
+              <Area
+                type="monotone"
+                dataKey="send"
+                name="Send Rate"
+                stroke={COLORS.send}
+                fill={COLORS.send}
+                fillOpacity={0.3}
+                strokeWidth={2}
+              />
+              <Area
+                type="monotone"
+                dataKey="receive"
+                name="Receive Rate"
+                stroke={COLORS.receive}
+                fill={COLORS.receive}
+                fillOpacity={0.3}
+                strokeWidth={2}
+              />
+              <Area
+                type="monotone"
+                dataKey="delete"
+                name="Delete Rate"
+                stroke={COLORS.delete}
+                fill={COLORS.delete}
+                fillOpacity={0.3}
+                strokeWidth={2}
+              />
+            </>
+          ) : (
+            <>
+              <Line
+                type="monotone"
+                dataKey="send"
+                name="Send Rate"
+                stroke={COLORS.send}
+                strokeWidth={2}
+                dot={false}
+                activeDot={{ r: 4 }}
+              />
+              <Line
+                type="monotone"
+                dataKey="receive"
+                name="Receive Rate"
+                stroke={COLORS.receive}
+                strokeWidth={2}
+                dot={false}
+                activeDot={{ r: 4 }}
+              />
+              <Line
+                type="monotone"
+                dataKey="delete"
+                name="Delete Rate"
+                stroke={COLORS.delete}
+                strokeWidth={2}
+                dot={false}
+                activeDot={{ r: 4 }}
+              />
+            </>
+          )}
+        </ChartComponent>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/internal/houston/ui/src/components/metrics/index.js
+++ b/internal/houston/ui/src/components/metrics/index.js
@@ -1,0 +1,6 @@
+export { default as MetricsDashboard } from "./MetricsDashboard";
+export { default as QueueDetailMetrics } from "./QueueDetailMetrics";
+export { default as RateChart } from "./RateChart";
+export { default as InFlightChart } from "./InFlightChart";
+export { default as MetricCard } from "./MetricCard";
+export { default as QueueMetricsTable } from "./QueueMetricsTable";

--- a/internal/houston/ui/src/components/navigation.jsx
+++ b/internal/houston/ui/src/components/navigation.jsx
@@ -1,6 +1,7 @@
 import {Tabs, TabsContent, TabsList, TabsTrigger} from "@/components/ui/tabs"
 import {Avatar, AvatarFallback, AvatarImage} from "@/components/ui/avatar"
 import Queues from "@/components/queues.jsx";
+import { MetricsDashboard } from "@/components/metrics";
 
 export default function Navigation() {
   return (
@@ -23,11 +24,15 @@ export default function Navigation() {
         <Tabs defaultValue="queues">
           <TabsList className="w-full justify-start">
             <TabsTrigger value="queues"><span className="">Queues</span></TabsTrigger>
+            <TabsTrigger value="metrics"><span className="">Metrics</span></TabsTrigger>
             <TabsTrigger value="pubsub"><span className="">PubSub</span></TabsTrigger>
             <TabsTrigger value="users&access"><span className="">Users & Access</span></TabsTrigger>
             <TabsTrigger value="settings"><span className="">Settings</span></TabsTrigger>
           </TabsList>
           <Queues/>
+          <TabsContent value="metrics" className="px-1 py-4">
+            <MetricsDashboard />
+          </TabsContent>
           <TabsContent value="pubsub" className="px-1">Make changes to your account here.</TabsContent>
           <TabsContent value="users&access" className="px-1">Change your password here.</TabsContent>
           <TabsContent value="settings" className="px-1">Change your password here.</TabsContent>

--- a/internal/houston/ui/src/components/queueDetails.jsx
+++ b/internal/houston/ui/src/components/queueDetails.jsx
@@ -1,17 +1,184 @@
-import { Tabs, TabsContent } from "@/components/ui/tabs";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { QueueDetailMetrics } from "@/components/metrics";
 
 export default function QueueDetails({ queueDetails, error }) {
+  if (error) {
+    return (
+      <div className="bg-white px-2 py-4">
+        <div className="text-red-500">Error: {error}</div>
+      </div>
+    );
+  }
+
+  if (!queueDetails) {
+    return (
+      <div className="bg-white px-2 py-4">
+        <div className="text-gray-500">Loading...</div>
+      </div>
+    );
+  }
+
   return (
     <div className="bg-white px-2">
       <Tabs defaultValue="queue" className="w-full">
         <TabsContent value="queue">
-          <div className="flex flex-row justify-between pt-4 pb-4">
-            <div>
-              <p className="text-2xl font-bold">Queue: {queueDetails.name}</p>
+          <div className="space-y-6">
+            {/* Queue header */}
+            <div className="flex flex-row justify-between pt-4 pb-4">
+              <div>
+                <p className="text-2xl font-bold">{queueDetails.queueName}</p>
+                <p className="text-sm text-gray-500">ID: {queueDetails.queueId}</p>
+              </div>
             </div>
+
+            {/* Queue tabs */}
+            <Tabs defaultValue="overview" className="w-full">
+              <TabsList>
+                <TabsTrigger value="overview">Overview</TabsTrigger>
+                <TabsTrigger value="metrics">Metrics</TabsTrigger>
+                <TabsTrigger value="settings">Settings</TabsTrigger>
+              </TabsList>
+
+              <TabsContent value="overview" className="space-y-4 pt-4">
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                  <Card>
+                    <CardHeader className="pb-2">
+                      <CardTitle className="text-sm font-medium text-gray-500">
+                        Retention Period
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="text-2xl font-bold">
+                        {formatDuration(queueDetails.retentionPeriodSeconds)}
+                      </div>
+                    </CardContent>
+                  </Card>
+
+                  <Card>
+                    <CardHeader className="pb-2">
+                      <CardTitle className="text-sm font-medium text-gray-500">
+                        Visibility Timeout
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="text-2xl font-bold">
+                        {queueDetails.visibilityTimeoutSeconds}s
+                      </div>
+                    </CardContent>
+                  </Card>
+
+                  <Card>
+                    <CardHeader className="pb-2">
+                      <CardTitle className="text-sm font-medium text-gray-500">
+                        Max Receive Attempts
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="text-2xl font-bold">
+                        {queueDetails.maxReceiveAttempts}
+                      </div>
+                    </CardContent>
+                  </Card>
+
+                  <Card>
+                    <CardHeader className="pb-2">
+                      <CardTitle className="text-sm font-medium text-gray-500">
+                        Eviction Policy
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="text-2xl font-bold">
+                        {formatEvictionPolicy(queueDetails.evictionPolicy)}
+                      </div>
+                    </CardContent>
+                  </Card>
+
+                  <Card>
+                    <CardHeader className="pb-2">
+                      <CardTitle className="text-sm font-medium text-gray-500">
+                        Created At
+                      </CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="text-lg font-medium">
+                        {new Date(queueDetails.createdAt).toLocaleString()}
+                      </div>
+                    </CardContent>
+                  </Card>
+
+                  {queueDetails.deadLetterQueueId && (
+                    <Card>
+                      <CardHeader className="pb-2">
+                        <CardTitle className="text-sm font-medium text-gray-500">
+                          Dead Letter Queue
+                        </CardTitle>
+                      </CardHeader>
+                      <CardContent>
+                        <a
+                          href={`/queue/${queueDetails.deadLetterQueueId}`}
+                          className="text-blue-600 hover:underline"
+                        >
+                          {queueDetails.deadLetterQueueId}
+                        </a>
+                      </CardContent>
+                    </Card>
+                  )}
+                </div>
+              </TabsContent>
+
+              <TabsContent value="metrics" className="pt-4">
+                <QueueDetailMetrics
+                  queueId={queueDetails.queueId}
+                  queueName={queueDetails.queueName}
+                />
+              </TabsContent>
+
+              <TabsContent value="settings" className="pt-4">
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Queue Settings</CardTitle>
+                    <CardDescription>
+                      Configure queue behavior and policies
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-gray-500">
+                      Queue settings management coming soon.
+                    </p>
+                  </CardContent>
+                </Card>
+              </TabsContent>
+            </Tabs>
           </div>
         </TabsContent>
       </Tabs>
     </div>
   );
+}
+
+function formatDuration(seconds) {
+  if (seconds >= 86400) {
+    const days = Math.floor(seconds / 86400);
+    return `${days} day${days > 1 ? "s" : ""}`;
+  }
+  if (seconds >= 3600) {
+    const hours = Math.floor(seconds / 3600);
+    return `${hours} hour${hours > 1 ? "s" : ""}`;
+  }
+  if (seconds >= 60) {
+    const minutes = Math.floor(seconds / 60);
+    return `${minutes} minute${minutes > 1 ? "s" : ""}`;
+  }
+  return `${seconds}s`;
+}
+
+function formatEvictionPolicy(policy) {
+  const policies = {
+    EVICTION_POLICY_UNSPECIFIED: "Unspecified",
+    EVICTION_POLICY_DROP: "Drop",
+    EVICTION_POLICY_DEAD_LETTER: "Dead Letter",
+    EVICTION_POLICY_REORDER: "Reorder",
+  };
+  return policies[policy] || policy;
 }

--- a/internal/server/metrics_handler.go
+++ b/internal/server/metrics_handler.go
@@ -116,22 +116,22 @@ func SelectResolution(tr TimeRange) string {
 
 // DashboardOverviewResponse represents the overview dashboard data.
 type DashboardOverviewResponse struct {
-	SystemMetrics  SystemMetricsData   `json:"systemMetrics"`
-	QueueMetrics   []QueueMetricsData  `json:"queueMetrics"`
-	TimeRange      TimeRange           `json:"timeRange"`
-	UpdatedAt      int64               `json:"updatedAt"`
+	SystemMetrics SystemMetricsData  `json:"systemMetrics"`
+	QueueMetrics  []QueueMetricsData `json:"queueMetrics"`
+	TimeRange     TimeRange          `json:"timeRange"`
+	UpdatedAt     int64              `json:"updatedAt"`
 }
 
 // SystemMetricsData represents system-wide metrics.
 type SystemMetricsData struct {
-	QueuesExist       int64   `json:"queuesExist"`
-	TotalInFlight     int64   `json:"totalInFlight"`
-	SendRate          float64 `json:"sendRate"`
-	ReceiveRate       float64 `json:"receiveRate"`
-	DeleteRate        float64 `json:"deleteRate"`
-	TotalSent         uint64  `json:"totalSent"`
-	TotalReceived     uint64  `json:"totalReceived"`
-	TotalDeleted      uint64  `json:"totalDeleted"`
+	QueuesExist   int64   `json:"queuesExist"`
+	TotalInFlight int64   `json:"totalInFlight"`
+	SendRate      float64 `json:"sendRate"`
+	ReceiveRate   float64 `json:"receiveRate"`
+	DeleteRate    float64 `json:"deleteRate"`
+	TotalSent     uint64  `json:"totalSent"`
+	TotalReceived uint64  `json:"totalReceived"`
+	TotalDeleted  uint64  `json:"totalDeleted"`
 }
 
 // QueueMetricsData represents metrics for a single queue.
@@ -150,11 +150,11 @@ type QueueMetricsData struct {
 
 // MetricsChartResponse represents time-series data for charts.
 type MetricsChartResponse struct {
-	MetricName string                 `json:"metricName"`
-	QueueID    string                 `json:"queueId,omitempty"`
-	TimeRange  TimeRange              `json:"timeRange"`
-	Resolution string                 `json:"resolution"`
-	DataPoints []collector.DataPoint  `json:"dataPoints"`
+	MetricName string                `json:"metricName"`
+	QueueID    string                `json:"queueId,omitempty"`
+	TimeRange  TimeRange             `json:"timeRange"`
+	Resolution string                `json:"resolution"`
+	DataPoints []collector.DataPoint `json:"dataPoints"`
 }
 
 // MultiMetricsChartResponse represents multiple metrics for comparison.
@@ -310,9 +310,9 @@ func (h *MetricsHandler) GetQueueMetrics(w http.ResponseWriter, r *http.Request)
 
 	resp := struct {
 		*collector.MetricsSummary
-		CurrentSendRate    float64 `json:"currentSendRate"`
-		CurrentReceiveRate float64 `json:"currentReceiveRate"`
-		CurrentDeleteRate  float64 `json:"currentDeleteRate"`
+		CurrentSendRate    float64   `json:"currentSendRate"`
+		CurrentReceiveRate float64   `json:"currentReceiveRate"`
+		CurrentDeleteRate  float64   `json:"currentDeleteRate"`
 		TimeRange          TimeRange `json:"timeRange"`
 	}{
 		MetricsSummary:     summary,

--- a/internal/server/metrics_handler.go
+++ b/internal/server/metrics_handler.go
@@ -1,0 +1,483 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/plainq/plainq/internal/server/telemetry/collector"
+	"github.com/plainq/servekit/respond"
+)
+
+// MetricsHandler handles metrics API requests.
+type MetricsHandler struct {
+	collector *collector.Collector
+	store     *collector.SQLiteStore
+}
+
+// NewMetricsHandler creates a new MetricsHandler.
+func NewMetricsHandler(c *collector.Collector, s *collector.SQLiteStore) *MetricsHandler {
+	return &MetricsHandler{
+		collector: c,
+		store:     s,
+	}
+}
+
+// TimeRange represents a time range for queries.
+type TimeRange struct {
+	From int64 `json:"from"`
+	To   int64 `json:"to"`
+}
+
+// TimeRangePreset represents preset time ranges like Grafana.
+type TimeRangePreset string
+
+const (
+	TimeRangeLast5m  TimeRangePreset = "5m"
+	TimeRangeLast15m TimeRangePreset = "15m"
+	TimeRangeLast30m TimeRangePreset = "30m"
+	TimeRangeLast1h  TimeRangePreset = "1h"
+	TimeRangeLast3h  TimeRangePreset = "3h"
+	TimeRangeLast6h  TimeRangePreset = "6h"
+	TimeRangeLast12h TimeRangePreset = "12h"
+	TimeRangeLast24h TimeRangePreset = "24h"
+	TimeRangeLast2d  TimeRangePreset = "2d"
+	TimeRangeLast7d  TimeRangePreset = "7d"
+	TimeRangeLast30d TimeRangePreset = "30d"
+	TimeRangeLast90d TimeRangePreset = "90d"
+	TimeRangeLast1y  TimeRangePreset = "1y"
+)
+
+// ParseTimeRange parses a time range preset or custom range.
+func ParseTimeRange(preset string, customFrom, customTo int64) TimeRange {
+	now := time.Now().UnixMilli()
+
+	if customFrom > 0 && customTo > 0 {
+		return TimeRange{From: customFrom, To: customTo}
+	}
+
+	var duration time.Duration
+	switch TimeRangePreset(preset) {
+	case TimeRangeLast5m:
+		duration = 5 * time.Minute
+	case TimeRangeLast15m:
+		duration = 15 * time.Minute
+	case TimeRangeLast30m:
+		duration = 30 * time.Minute
+	case TimeRangeLast1h:
+		duration = 1 * time.Hour
+	case TimeRangeLast3h:
+		duration = 3 * time.Hour
+	case TimeRangeLast6h:
+		duration = 6 * time.Hour
+	case TimeRangeLast12h:
+		duration = 12 * time.Hour
+	case TimeRangeLast24h:
+		duration = 24 * time.Hour
+	case TimeRangeLast2d:
+		duration = 2 * 24 * time.Hour
+	case TimeRangeLast7d:
+		duration = 7 * 24 * time.Hour
+	case TimeRangeLast30d:
+		duration = 30 * 24 * time.Hour
+	case TimeRangeLast90d:
+		duration = 90 * 24 * time.Hour
+	case TimeRangeLast1y:
+		duration = 365 * 24 * time.Hour
+	default:
+		duration = 1 * time.Hour // Default to last hour
+	}
+
+	return TimeRange{
+		From: now - int64(duration.Milliseconds()),
+		To:   now,
+	}
+}
+
+// SelectResolution automatically selects appropriate resolution based on time range.
+func SelectResolution(tr TimeRange) string {
+	duration := time.Duration(tr.To-tr.From) * time.Millisecond
+
+	switch {
+	case duration <= 1*time.Hour:
+		return "raw"
+	case duration <= 6*time.Hour:
+		return "1m"
+	case duration <= 24*time.Hour:
+		return "5m"
+	case duration <= 7*24*time.Hour:
+		return "1h"
+	default:
+		return "1d"
+	}
+}
+
+// DashboardOverviewResponse represents the overview dashboard data.
+type DashboardOverviewResponse struct {
+	SystemMetrics  SystemMetricsData   `json:"systemMetrics"`
+	QueueMetrics   []QueueMetricsData  `json:"queueMetrics"`
+	TimeRange      TimeRange           `json:"timeRange"`
+	UpdatedAt      int64               `json:"updatedAt"`
+}
+
+// SystemMetricsData represents system-wide metrics.
+type SystemMetricsData struct {
+	QueuesExist       int64   `json:"queuesExist"`
+	TotalInFlight     int64   `json:"totalInFlight"`
+	SendRate          float64 `json:"sendRate"`
+	ReceiveRate       float64 `json:"receiveRate"`
+	DeleteRate        float64 `json:"deleteRate"`
+	TotalSent         uint64  `json:"totalSent"`
+	TotalReceived     uint64  `json:"totalReceived"`
+	TotalDeleted      uint64  `json:"totalDeleted"`
+}
+
+// QueueMetricsData represents metrics for a single queue.
+type QueueMetricsData struct {
+	QueueID          string  `json:"queueId"`
+	QueueName        string  `json:"queueName,omitempty"`
+	InFlight         int64   `json:"inFlight"`
+	SendRate         float64 `json:"sendRate"`
+	ReceiveRate      float64 `json:"receiveRate"`
+	DeleteRate       float64 `json:"deleteRate"`
+	MessagesSent     uint64  `json:"messagesSent"`
+	MessagesReceived uint64  `json:"messagesReceived"`
+	MessagesDeleted  uint64  `json:"messagesDeleted"`
+	EmptyReceives    uint64  `json:"emptyReceives"`
+}
+
+// MetricsChartResponse represents time-series data for charts.
+type MetricsChartResponse struct {
+	MetricName string                 `json:"metricName"`
+	QueueID    string                 `json:"queueId,omitempty"`
+	TimeRange  TimeRange              `json:"timeRange"`
+	Resolution string                 `json:"resolution"`
+	DataPoints []collector.DataPoint  `json:"dataPoints"`
+}
+
+// MultiMetricsChartResponse represents multiple metrics for comparison.
+type MultiMetricsChartResponse struct {
+	Metrics   []MetricsChartResponse `json:"metrics"`
+	TimeRange TimeRange              `json:"timeRange"`
+}
+
+// GetDashboardOverview returns the overview dashboard data.
+func (h *MetricsHandler) GetDashboardOverview(w http.ResponseWriter, r *http.Request) {
+	// Get system rates.
+	sendRate, receiveRate, deleteRate := h.collector.GetSystemRates()
+
+	// Build system metrics.
+	systemMetrics := SystemMetricsData{
+		TotalInFlight: h.collector.GetSystemInFlightCount(),
+		SendRate:      sendRate,
+		ReceiveRate:   receiveRate,
+		DeleteRate:    deleteRate,
+	}
+
+	// Build per-queue metrics.
+	queueIDs := h.collector.GetAllQueueIDs()
+	queueMetrics := make([]QueueMetricsData, 0, len(queueIDs))
+
+	for _, queueID := range queueIDs {
+		sr, rr, dr := h.collector.GetRates(queueID)
+		counters := h.collector.GetCounters(queueID)
+
+		queueMetrics = append(queueMetrics, QueueMetricsData{
+			QueueID:          queueID,
+			InFlight:         h.collector.GetInFlightCount(queueID),
+			SendRate:         sr,
+			ReceiveRate:      rr,
+			DeleteRate:       dr,
+			MessagesSent:     counters[collector.MetricMessagesSentTotal],
+			MessagesReceived: counters[collector.MetricMessagesReceivedTotal],
+			MessagesDeleted:  counters[collector.MetricMessagesDeletedTotal],
+			EmptyReceives:    counters[collector.MetricEmptyReceivesTotal],
+		})
+	}
+
+	resp := DashboardOverviewResponse{
+		SystemMetrics: systemMetrics,
+		QueueMetrics:  queueMetrics,
+		TimeRange:     TimeRange{From: time.Now().Add(-1 * time.Hour).UnixMilli(), To: time.Now().UnixMilli()},
+		UpdatedAt:     time.Now().UnixMilli(),
+	}
+
+	respond.JSON(w, r, resp)
+}
+
+// GetMetricsChart returns time-series data for a metric.
+func (h *MetricsHandler) GetMetricsChart(w http.ResponseWriter, r *http.Request) {
+	metricName := r.URL.Query().Get("metric")
+	if metricName == "" {
+		http.Error(w, `{"error": "metric parameter required"}`, http.StatusBadRequest)
+		return
+	}
+
+	queueID := r.URL.Query().Get("queue_id")
+	preset := r.URL.Query().Get("range")
+	resolution := r.URL.Query().Get("resolution")
+
+	var customFrom, customTo int64
+	if fromStr := r.URL.Query().Get("from"); fromStr != "" {
+		customFrom, _ = strconv.ParseInt(fromStr, 10, 64)
+	}
+	if toStr := r.URL.Query().Get("to"); toStr != "" {
+		customTo, _ = strconv.ParseInt(toStr, 10, 64)
+	}
+
+	tr := ParseTimeRange(preset, customFrom, customTo)
+
+	if resolution == "" {
+		resolution = SelectResolution(tr)
+	}
+
+	// Get data from store.
+	dataPoints, err := h.store.GetMetrics(r.Context(), metricName, queueID, tr.From, tr.To, resolution)
+	if err != nil {
+		http.Error(w, `{"error": "`+err.Error()+`"}`, http.StatusInternalServerError)
+		return
+	}
+
+	resp := MetricsChartResponse{
+		MetricName: metricName,
+		QueueID:    queueID,
+		TimeRange:  tr,
+		Resolution: resolution,
+		DataPoints: dataPoints,
+	}
+
+	respond.JSON(w, r, resp)
+}
+
+// GetRatesChart returns rate history for a queue.
+func (h *MetricsHandler) GetRatesChart(w http.ResponseWriter, r *http.Request) {
+	queueID := chi.URLParam(r, "id")
+	preset := r.URL.Query().Get("range")
+
+	var customFrom, customTo int64
+	if fromStr := r.URL.Query().Get("from"); fromStr != "" {
+		customFrom, _ = strconv.ParseInt(fromStr, 10, 64)
+	}
+	if toStr := r.URL.Query().Get("to"); toStr != "" {
+		customTo, _ = strconv.ParseInt(toStr, 10, 64)
+	}
+
+	tr := ParseTimeRange(preset, customFrom, customTo)
+
+	// Get rate history for all rate types.
+	sendRates, _ := h.store.GetRateHistory(r.Context(), collector.MetricSendRate, queueID, tr.From, tr.To)
+	receiveRates, _ := h.store.GetRateHistory(r.Context(), collector.MetricReceiveRate, queueID, tr.From, tr.To)
+	deleteRates, _ := h.store.GetRateHistory(r.Context(), collector.MetricDeleteRate, queueID, tr.From, tr.To)
+
+	resp := MultiMetricsChartResponse{
+		Metrics: []MetricsChartResponse{
+			{MetricName: collector.MetricSendRate, QueueID: queueID, DataPoints: sendRates},
+			{MetricName: collector.MetricReceiveRate, QueueID: queueID, DataPoints: receiveRates},
+			{MetricName: collector.MetricDeleteRate, QueueID: queueID, DataPoints: deleteRates},
+		},
+		TimeRange: tr,
+	}
+
+	respond.JSON(w, r, resp)
+}
+
+// GetQueueMetrics returns detailed metrics for a specific queue.
+func (h *MetricsHandler) GetQueueMetrics(w http.ResponseWriter, r *http.Request) {
+	queueID := chi.URLParam(r, "id")
+	preset := r.URL.Query().Get("range")
+
+	var customFrom, customTo int64
+	if fromStr := r.URL.Query().Get("from"); fromStr != "" {
+		customFrom, _ = strconv.ParseInt(fromStr, 10, 64)
+	}
+	if toStr := r.URL.Query().Get("to"); toStr != "" {
+		customTo, _ = strconv.ParseInt(toStr, 10, 64)
+	}
+
+	tr := ParseTimeRange(preset, customFrom, customTo)
+
+	// Get summary.
+	summary, err := h.store.GetMetricsSummary(r.Context(), queueID, tr.From, tr.To)
+	if err != nil {
+		http.Error(w, `{"error": "`+err.Error()+`"}`, http.StatusInternalServerError)
+		return
+	}
+
+	// Get current rates.
+	sr, rr, dr := h.collector.GetRates(queueID)
+
+	resp := struct {
+		*collector.MetricsSummary
+		CurrentSendRate    float64 `json:"currentSendRate"`
+		CurrentReceiveRate float64 `json:"currentReceiveRate"`
+		CurrentDeleteRate  float64 `json:"currentDeleteRate"`
+		TimeRange          TimeRange `json:"timeRange"`
+	}{
+		MetricsSummary:     summary,
+		CurrentSendRate:    sr,
+		CurrentReceiveRate: rr,
+		CurrentDeleteRate:  dr,
+		TimeRange:          tr,
+	}
+
+	respond.JSON(w, r, resp)
+}
+
+// GetInFlightMetrics returns in-flight message counts.
+func (h *MetricsHandler) GetInFlightMetrics(w http.ResponseWriter, r *http.Request) {
+	queueID := chi.URLParam(r, "id")
+
+	var count int64
+	if queueID != "" {
+		count = h.collector.GetInFlightCount(queueID)
+	} else {
+		count = h.collector.GetSystemInFlightCount()
+	}
+
+	// Also get history from store.
+	preset := r.URL.Query().Get("range")
+	tr := ParseTimeRange(preset, 0, 0)
+
+	history, _ := h.store.GetMetrics(r.Context(), collector.MetricMessagesInFlight, queueID, tr.From, tr.To, SelectResolution(tr))
+
+	resp := struct {
+		Current   int64                 `json:"current"`
+		QueueID   string                `json:"queueId,omitempty"`
+		History   []collector.DataPoint `json:"history"`
+		TimeRange TimeRange             `json:"timeRange"`
+	}{
+		Current:   count,
+		QueueID:   queueID,
+		History:   history,
+		TimeRange: tr,
+	}
+
+	respond.JSON(w, r, resp)
+}
+
+// GetAvailableMetrics returns list of available metrics.
+func (h *MetricsHandler) GetAvailableMetrics(w http.ResponseWriter, r *http.Request) {
+	metrics := []struct {
+		Name        string `json:"name"`
+		Type        string `json:"type"`
+		Description string `json:"description"`
+	}{
+		{collector.MetricSendRate, "gauge", "Messages sent per second"},
+		{collector.MetricReceiveRate, "gauge", "Messages received per second"},
+		{collector.MetricDeleteRate, "gauge", "Messages deleted per second"},
+		{collector.MetricMessagesInFlight, "gauge", "Messages currently being processed"},
+		{collector.MetricQueueDepth, "gauge", "Total messages in queue"},
+		{collector.MetricMessagesVisible, "gauge", "Messages available to receive"},
+		{collector.MetricMessagesInvisible, "gauge", "Messages being processed"},
+		{collector.MetricOldestMessageAge, "gauge", "Age of oldest message in seconds"},
+		{collector.MetricMessagesSentTotal, "counter", "Total messages sent"},
+		{collector.MetricMessagesReceivedTotal, "counter", "Total messages received"},
+		{collector.MetricMessagesDeletedTotal, "counter", "Total messages deleted"},
+		{collector.MetricEmptyReceivesTotal, "counter", "Total empty receive attempts"},
+		{collector.MetricMessagesRedelivered, "counter", "Total messages redelivered"},
+		{collector.MetricMessagesToDLQ, "counter", "Total messages moved to DLQ"},
+		{collector.MetricMessageProcessingDuration, "histogram", "Message processing duration"},
+		{collector.MetricMessageDwellTime, "histogram", "Time from send to receive"},
+		{collector.MetricBatchSize, "histogram", "Batch operation sizes"},
+		{collector.MetricMessageSizeBytes, "histogram", "Message body sizes"},
+	}
+
+	respond.JSON(w, r, metrics)
+}
+
+// GetTimeRangePresets returns available time range presets.
+func (h *MetricsHandler) GetTimeRangePresets(w http.ResponseWriter, r *http.Request) {
+	presets := []struct {
+		Value string `json:"value"`
+		Label string `json:"label"`
+	}{
+		{string(TimeRangeLast5m), "Last 5 minutes"},
+		{string(TimeRangeLast15m), "Last 15 minutes"},
+		{string(TimeRangeLast30m), "Last 30 minutes"},
+		{string(TimeRangeLast1h), "Last 1 hour"},
+		{string(TimeRangeLast3h), "Last 3 hours"},
+		{string(TimeRangeLast6h), "Last 6 hours"},
+		{string(TimeRangeLast12h), "Last 12 hours"},
+		{string(TimeRangeLast24h), "Last 24 hours"},
+		{string(TimeRangeLast2d), "Last 2 days"},
+		{string(TimeRangeLast7d), "Last 7 days"},
+		{string(TimeRangeLast30d), "Last 30 days"},
+		{string(TimeRangeLast90d), "Last 90 days"},
+		{string(TimeRangeLast1y), "Last 1 year"},
+	}
+
+	respond.JSON(w, r, presets)
+}
+
+// ExportMetrics exports metrics in a format suitable for Metabase.
+func (h *MetricsHandler) ExportMetrics(w http.ResponseWriter, r *http.Request) {
+	format := r.URL.Query().Get("format")
+	if format == "" {
+		format = "json"
+	}
+
+	metricName := r.URL.Query().Get("metric")
+	queueID := r.URL.Query().Get("queue_id")
+	preset := r.URL.Query().Get("range")
+
+	var customFrom, customTo int64
+	if fromStr := r.URL.Query().Get("from"); fromStr != "" {
+		customFrom, _ = strconv.ParseInt(fromStr, 10, 64)
+	}
+	if toStr := r.URL.Query().Get("to"); toStr != "" {
+		customTo, _ = strconv.ParseInt(toStr, 10, 64)
+	}
+
+	tr := ParseTimeRange(preset, customFrom, customTo)
+	resolution := SelectResolution(tr)
+
+	dataPoints, err := h.store.GetMetrics(r.Context(), metricName, queueID, tr.From, tr.To, resolution)
+	if err != nil {
+		http.Error(w, `{"error": "`+err.Error()+`"}`, http.StatusInternalServerError)
+		return
+	}
+
+	switch format {
+	case "csv":
+		w.Header().Set("Content-Type", "text/csv")
+		w.Header().Set("Content-Disposition", "attachment; filename=metrics.csv")
+		w.Write([]byte("timestamp,value,min,max,avg,sum,count\n"))
+		for _, p := range dataPoints {
+			line := strconv.FormatInt(p.Timestamp, 10) + "," +
+				strconv.FormatFloat(p.Value, 'f', 6, 64) + "," +
+				strconv.FormatFloat(p.Min, 'f', 6, 64) + "," +
+				strconv.FormatFloat(p.Max, 'f', 6, 64) + "," +
+				strconv.FormatFloat(p.Avg, 'f', 6, 64) + "," +
+				strconv.FormatFloat(p.Sum, 'f', 6, 64) + "," +
+				strconv.FormatInt(p.Count, 10) + "\n"
+			w.Write([]byte(line))
+		}
+	default:
+		// Metabase-friendly JSON format.
+		export := struct {
+			Columns []string        `json:"columns"`
+			Rows    [][]interface{} `json:"rows"`
+		}{
+			Columns: []string{"timestamp", "datetime", "value", "min", "max", "avg", "sum", "count"},
+			Rows:    make([][]interface{}, len(dataPoints)),
+		}
+
+		for i, p := range dataPoints {
+			export.Rows[i] = []interface{}{
+				p.Timestamp,
+				time.UnixMilli(p.Timestamp).Format(time.RFC3339),
+				p.Value,
+				p.Min,
+				p.Max,
+				p.Avg,
+				p.Sum,
+				p.Count,
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(export)
+	}
+}

--- a/internal/server/mutations/telemetry/3_metrics_enhanced.sql
+++ b/internal/server/mutations/telemetry/3_metrics_enhanced.sql
@@ -1,0 +1,120 @@
+-- Enhanced metrics schema with multiple retention tiers (like Grafana/Prometheus)
+-- Retention tiers:
+--   metrics_raw:  1-second resolution, 1-hour retention
+--   metrics_1m:   1-minute aggregates, 24-hour retention
+--   metrics_5m:   5-minute aggregates, 7-day retention (already exists, enhanced)
+--   metrics_1h:   1-hour aggregates, 30-day retention
+--   metrics_1d:   1-day aggregates, 1-year retention
+
+-- Raw metrics table (1-second resolution, 1-hour retention)
+CREATE TABLE IF NOT EXISTS "metrics_raw" (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp INTEGER NOT NULL,  -- Unix timestamp in milliseconds
+    queue_id TEXT NOT NULL DEFAULT '',  -- Empty for system-wide metrics
+    metric_name TEXT NOT NULL,
+    metric_value REAL NOT NULL,
+    labels TEXT NOT NULL DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS idx_metrics_raw_timestamp ON metrics_raw(timestamp);
+CREATE INDEX IF NOT EXISTS idx_metrics_raw_queue ON metrics_raw(queue_id);
+CREATE INDEX IF NOT EXISTS idx_metrics_raw_metric ON metrics_raw(metric_name);
+CREATE INDEX IF NOT EXISTS idx_metrics_raw_composite ON metrics_raw(metric_name, queue_id, timestamp);
+
+-- 1-minute aggregates (24-hour retention)
+CREATE TABLE IF NOT EXISTS "metrics_1m" (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    bucket_start INTEGER NOT NULL,  -- Unix timestamp (start of minute)
+    queue_id TEXT NOT NULL DEFAULT '',
+    metric_name TEXT NOT NULL,
+    min_value REAL NOT NULL,
+    max_value REAL NOT NULL,
+    avg_value REAL NOT NULL,
+    sum_value REAL NOT NULL,
+    count INTEGER NOT NULL,
+    labels TEXT NOT NULL DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS idx_metrics_1m_bucket ON metrics_1m(bucket_start);
+CREATE INDEX IF NOT EXISTS idx_metrics_1m_queue ON metrics_1m(queue_id);
+CREATE INDEX IF NOT EXISTS idx_metrics_1m_metric ON metrics_1m(metric_name);
+CREATE INDEX IF NOT EXISTS idx_metrics_1m_composite ON metrics_1m(metric_name, queue_id, bucket_start);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_metrics_1m_unique ON metrics_1m(bucket_start, queue_id, metric_name, labels);
+
+-- 1-hour aggregates (30-day retention)
+CREATE TABLE IF NOT EXISTS "metrics_1h" (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    bucket_start INTEGER NOT NULL,  -- Unix timestamp (start of hour)
+    queue_id TEXT NOT NULL DEFAULT '',
+    metric_name TEXT NOT NULL,
+    min_value REAL NOT NULL,
+    max_value REAL NOT NULL,
+    avg_value REAL NOT NULL,
+    sum_value REAL NOT NULL,
+    count INTEGER NOT NULL,
+    labels TEXT NOT NULL DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS idx_metrics_1h_bucket ON metrics_1h(bucket_start);
+CREATE INDEX IF NOT EXISTS idx_metrics_1h_queue ON metrics_1h(queue_id);
+CREATE INDEX IF NOT EXISTS idx_metrics_1h_metric ON metrics_1h(metric_name);
+CREATE INDEX IF NOT EXISTS idx_metrics_1h_composite ON metrics_1h(metric_name, queue_id, bucket_start);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_metrics_1h_unique ON metrics_1h(bucket_start, queue_id, metric_name, labels);
+
+-- 1-day aggregates (1-year retention)
+CREATE TABLE IF NOT EXISTS "metrics_1d" (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    bucket_start INTEGER NOT NULL,  -- Unix timestamp (start of day, UTC)
+    queue_id TEXT NOT NULL DEFAULT '',
+    metric_name TEXT NOT NULL,
+    min_value REAL NOT NULL,
+    max_value REAL NOT NULL,
+    avg_value REAL NOT NULL,
+    sum_value REAL NOT NULL,
+    count INTEGER NOT NULL,
+    labels TEXT NOT NULL DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS idx_metrics_1d_bucket ON metrics_1d(bucket_start);
+CREATE INDEX IF NOT EXISTS idx_metrics_1d_queue ON metrics_1d(queue_id);
+CREATE INDEX IF NOT EXISTS idx_metrics_1d_metric ON metrics_1d(metric_name);
+CREATE INDEX IF NOT EXISTS idx_metrics_1d_composite ON metrics_1d(metric_name, queue_id, bucket_start);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_metrics_1d_unique ON metrics_1d(bucket_start, queue_id, metric_name, labels);
+
+-- In-flight messages tracking table (real-time gauge data)
+CREATE TABLE IF NOT EXISTS "messages_in_flight" (
+    queue_id TEXT PRIMARY KEY,
+    count INTEGER NOT NULL DEFAULT 0,
+    updated_at INTEGER NOT NULL  -- Unix timestamp in milliseconds
+);
+
+-- Queue statistics snapshot table (for queue depth, oldest message, etc.)
+CREATE TABLE IF NOT EXISTS "queue_stats_snapshot" (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp INTEGER NOT NULL,
+    queue_id TEXT NOT NULL,
+    queue_depth INTEGER NOT NULL DEFAULT 0,
+    messages_visible INTEGER NOT NULL DEFAULT 0,
+    messages_invisible INTEGER NOT NULL DEFAULT 0,
+    oldest_message_age_seconds REAL NOT NULL DEFAULT 0,
+    avg_message_age_seconds REAL NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_queue_stats_timestamp ON queue_stats_snapshot(timestamp);
+CREATE INDEX IF NOT EXISTS idx_queue_stats_queue ON queue_stats_snapshot(queue_id);
+CREATE INDEX IF NOT EXISTS idx_queue_stats_composite ON queue_stats_snapshot(queue_id, timestamp);
+
+-- Rate tracking table (for real-time rate calculations)
+CREATE TABLE IF NOT EXISTS "rate_snapshots" (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp INTEGER NOT NULL,  -- Unix timestamp in milliseconds
+    queue_id TEXT NOT NULL DEFAULT '',  -- Empty for system-wide
+    metric_name TEXT NOT NULL,  -- e.g., 'send_rate', 'receive_rate', 'delete_rate'
+    rate_per_second REAL NOT NULL,
+    window_seconds INTEGER NOT NULL DEFAULT 1  -- The window over which rate was calculated
+);
+
+CREATE INDEX IF NOT EXISTS idx_rate_timestamp ON rate_snapshots(timestamp);
+CREATE INDEX IF NOT EXISTS idx_rate_queue ON rate_snapshots(queue_id);
+CREATE INDEX IF NOT EXISTS idx_rate_metric ON rate_snapshots(metric_name);
+CREATE INDEX IF NOT EXISTS idx_rate_composite ON rate_snapshots(metric_name, queue_id, timestamp);

--- a/internal/server/telemetry/collector/collector.go
+++ b/internal/server/telemetry/collector/collector.go
@@ -1,0 +1,637 @@
+// Package collector provides a comprehensive metrics collection system
+// for tracking queue operations with rate calculations, in-flight tracking,
+// and time-series storage.
+package collector
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/plainq/servekit/logkit"
+)
+
+const (
+	// Default collection interval for rate calculations.
+	defaultCollectionInterval = 1 * time.Second
+
+	// Default snapshot interval for queue statistics.
+	defaultSnapshotInterval = 5 * time.Second
+
+	// Default aggregation intervals.
+	aggregationInterval1m = 1 * time.Minute
+	aggregationInterval1h = 1 * time.Hour
+	aggregationInterval1d = 24 * time.Hour
+
+	// Retention periods (like Grafana defaults).
+	retentionRaw = 1 * time.Hour
+	retention1m  = 24 * time.Hour
+	retention5m  = 7 * 24 * time.Hour
+	retention1h  = 30 * 24 * time.Hour
+	retention1d  = 365 * 24 * time.Hour
+)
+
+// MetricType represents the type of metric.
+type MetricType string
+
+const (
+	MetricTypeCounter   MetricType = "counter"
+	MetricTypeGauge     MetricType = "gauge"
+	MetricTypeHistogram MetricType = "histogram"
+)
+
+// Metric names constants.
+const (
+	// Rate metrics (calculated per second).
+	MetricSendRate    = "plainq_send_rate"
+	MetricReceiveRate = "plainq_receive_rate"
+	MetricDeleteRate  = "plainq_delete_rate"
+
+	// Counter metrics (cumulative).
+	MetricMessagesSentTotal     = "plainq_messages_sent_total"
+	MetricMessagesReceivedTotal = "plainq_messages_received_total"
+	MetricMessagesDeletedTotal  = "plainq_messages_deleted_total"
+	MetricMessagesDroppedTotal  = "plainq_messages_dropped_total"
+	MetricEmptyReceivesTotal    = "plainq_empty_receives_total"
+	MetricMessagesRedelivered   = "plainq_messages_redelivered_total"
+	MetricMessagesToDLQ         = "plainq_messages_to_dlq_total"
+	MetricBytesSentTotal        = "plainq_bytes_sent_total"
+	MetricBytesReceivedTotal    = "plainq_bytes_received_total"
+
+	// Gauge metrics (current value).
+	MetricMessagesInFlight      = "plainq_messages_in_flight"
+	MetricQueueDepth            = "plainq_queue_depth"
+	MetricMessagesVisible       = "plainq_messages_visible"
+	MetricMessagesInvisible     = "plainq_messages_invisible"
+	MetricOldestMessageAge      = "plainq_oldest_message_age_seconds"
+	MetricQueuesExist           = "plainq_queues_exist"
+	MetricThroughputBytesPerSec = "plainq_throughput_bytes_per_second"
+
+	// Histogram metrics (distribution).
+	MetricMessageProcessingDuration = "plainq_message_processing_duration_seconds"
+	MetricMessageDwellTime          = "plainq_message_dwell_time_seconds"
+	MetricMessageInQueueDuration    = "plainq_message_in_queue_duration_seconds"
+	MetricBatchSize                 = "plainq_batch_size"
+	MetricMessageSizeBytes          = "plainq_message_size_bytes"
+)
+
+// QueueMetrics holds metrics for a specific queue.
+type QueueMetrics struct {
+	// Counters (atomic for thread safety).
+	messagesSent     atomic.Uint64
+	messagesReceived atomic.Uint64
+	messagesDeleted  atomic.Uint64
+	messagesDropped  atomic.Uint64
+	emptyReceives    atomic.Uint64
+	messagesRedelivered atomic.Uint64
+	messagesToDLQ    atomic.Uint64
+	bytesSent        atomic.Uint64
+	bytesReceived    atomic.Uint64
+
+	// In-flight tracking.
+	messagesInFlight atomic.Int64
+
+	// Previous values for rate calculation.
+	prevSent     uint64
+	prevReceived uint64
+	prevDeleted  uint64
+	prevBytes    uint64
+
+	// Calculated rates.
+	sendRate    atomic.Uint64 // Stored as float64 bits
+	receiveRate atomic.Uint64
+	deleteRate  atomic.Uint64
+
+	// Histogram accumulators (simplified - use summary stats).
+	processingDurations []float64
+	dwellTimes          []float64
+	batchSizes          []int
+	messageSizes        []int
+	histogramMu         sync.Mutex
+}
+
+// SystemMetrics holds system-wide metrics.
+type SystemMetrics struct {
+	queuesExist atomic.Int64
+
+	// Aggregate counters.
+	totalSent     atomic.Uint64
+	totalReceived atomic.Uint64
+	totalDeleted  atomic.Uint64
+
+	// Previous values for system-wide rates.
+	prevTotalSent     uint64
+	prevTotalReceived uint64
+	prevTotalDeleted  uint64
+
+	// System-wide rates.
+	systemSendRate    atomic.Uint64
+	systemReceiveRate atomic.Uint64
+	systemDeleteRate  atomic.Uint64
+}
+
+// Collector manages metrics collection, rate calculations, and storage.
+type Collector struct {
+	logger *slog.Logger
+	store  Store
+
+	// Per-queue metrics.
+	queueMetrics map[string]*QueueMetrics
+	queueMu      sync.RWMutex
+
+	// System-wide metrics.
+	system SystemMetrics
+
+	// Configuration.
+	collectionInterval time.Duration
+	snapshotInterval   time.Duration
+
+	// Control.
+	stop     chan struct{}
+	stopOnce sync.Once
+}
+
+// Store interface for persisting metrics.
+type Store interface {
+	// SaveRawMetric saves a raw metric data point.
+	SaveRawMetric(ctx context.Context, timestamp int64, queueID, metricName string, value float64, labels string) error
+
+	// SaveRateSnapshot saves rate calculation results.
+	SaveRateSnapshot(ctx context.Context, timestamp int64, queueID, metricName string, ratePerSecond float64, windowSeconds int) error
+
+	// SaveQueueStats saves queue statistics snapshot.
+	SaveQueueStats(ctx context.Context, timestamp int64, queueID string, depth, visible, invisible int64, oldestAge, avgAge float64) error
+
+	// UpdateInFlightCount updates the in-flight message count for a queue.
+	UpdateInFlightCount(ctx context.Context, queueID string, count int64) error
+
+	// Aggregate1m aggregates raw metrics into 1-minute buckets.
+	Aggregate1m(ctx context.Context, fromTimestamp, toTimestamp int64) error
+
+	// Aggregate1h aggregates 1-minute metrics into 1-hour buckets.
+	Aggregate1h(ctx context.Context, fromTimestamp, toTimestamp int64) error
+
+	// Aggregate1d aggregates 1-hour metrics into 1-day buckets.
+	Aggregate1d(ctx context.Context, fromTimestamp, toTimestamp int64) error
+
+	// CleanupOldMetrics removes metrics older than retention period.
+	CleanupOldMetrics(ctx context.Context, rawBefore, m1Before, m5Before, h1Before, d1Before int64) error
+
+	// GetMetrics retrieves metrics for a time range.
+	GetMetrics(ctx context.Context, metricName, queueID string, from, to int64, resolution string) ([]DataPoint, error)
+
+	// GetLatestRates retrieves the latest rate values.
+	GetLatestRates(ctx context.Context, queueID string) (map[string]float64, error)
+
+	// GetQueueStats retrieves queue statistics.
+	GetQueueStats(ctx context.Context, queueID string, from, to int64) ([]QueueStatsPoint, error)
+}
+
+// DataPoint represents a single metric data point.
+type DataPoint struct {
+	Timestamp int64   `json:"timestamp"`
+	Value     float64 `json:"value"`
+	Min       float64 `json:"min,omitempty"`
+	Max       float64 `json:"max,omitempty"`
+	Avg       float64 `json:"avg,omitempty"`
+	Sum       float64 `json:"sum,omitempty"`
+	Count     int64   `json:"count,omitempty"`
+}
+
+// QueueStatsPoint represents queue statistics at a point in time.
+type QueueStatsPoint struct {
+	Timestamp        int64   `json:"timestamp"`
+	QueueDepth       int64   `json:"queueDepth"`
+	MessagesVisible  int64   `json:"messagesVisible"`
+	MessagesInvisible int64  `json:"messagesInvisible"`
+	OldestMessageAge float64 `json:"oldestMessageAge"`
+	AvgMessageAge    float64 `json:"avgMessageAge"`
+}
+
+// Option configures the Collector.
+type Option func(*Collector)
+
+// WithLogger sets the logger.
+func WithLogger(logger *slog.Logger) Option {
+	return func(c *Collector) { c.logger = logger }
+}
+
+// WithCollectionInterval sets the collection interval.
+func WithCollectionInterval(d time.Duration) Option {
+	return func(c *Collector) { c.collectionInterval = d }
+}
+
+// WithSnapshotInterval sets the snapshot interval.
+func WithSnapshotInterval(d time.Duration) Option {
+	return func(c *Collector) { c.snapshotInterval = d }
+}
+
+// New creates a new Collector.
+func New(store Store, opts ...Option) *Collector {
+	c := &Collector{
+		logger:             logkit.NewNop(),
+		store:              store,
+		queueMetrics:       make(map[string]*QueueMetrics),
+		collectionInterval: defaultCollectionInterval,
+		snapshotInterval:   defaultSnapshotInterval,
+		stop:               make(chan struct{}),
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
+}
+
+// Start begins the metrics collection background workers.
+func (c *Collector) Start(ctx context.Context) {
+	// Rate calculation worker.
+	go c.rateCalculationWorker(ctx)
+
+	// Aggregation workers.
+	go c.aggregationWorker(ctx, aggregationInterval1m, "1m", c.aggregate1m)
+	go c.aggregationWorker(ctx, aggregationInterval1h, "1h", c.aggregate1h)
+	go c.aggregationWorker(ctx, aggregationInterval1d, "1d", c.aggregate1d)
+
+	// Cleanup worker.
+	go c.cleanupWorker(ctx)
+
+	c.logger.Info("Metrics collector started")
+}
+
+// Stop stops the collector.
+func (c *Collector) Stop() {
+	c.stopOnce.Do(func() {
+		close(c.stop)
+		c.logger.Info("Metrics collector stopped")
+	})
+}
+
+// getOrCreateQueueMetrics gets or creates metrics for a queue.
+func (c *Collector) getOrCreateQueueMetrics(queueID string) *QueueMetrics {
+	c.queueMu.RLock()
+	m, ok := c.queueMetrics[queueID]
+	c.queueMu.RUnlock()
+
+	if ok {
+		return m
+	}
+
+	c.queueMu.Lock()
+	defer c.queueMu.Unlock()
+
+	// Double-check after acquiring write lock.
+	if m, ok = c.queueMetrics[queueID]; ok {
+		return m
+	}
+
+	m = &QueueMetrics{
+		processingDurations: make([]float64, 0, 1000),
+		dwellTimes:          make([]float64, 0, 1000),
+		batchSizes:          make([]int, 0, 100),
+		messageSizes:        make([]int, 0, 1000),
+	}
+	c.queueMetrics[queueID] = m
+	return m
+}
+
+// RecordSend records a send operation.
+func (c *Collector) RecordSend(queueID string, count uint64, totalBytes uint64) {
+	m := c.getOrCreateQueueMetrics(queueID)
+	m.messagesSent.Add(count)
+	m.bytesSent.Add(totalBytes)
+	c.system.totalSent.Add(count)
+}
+
+// RecordReceive records a receive operation.
+func (c *Collector) RecordReceive(queueID string, count uint64, isEmpty bool) {
+	m := c.getOrCreateQueueMetrics(queueID)
+	m.messagesReceived.Add(count)
+	m.messagesInFlight.Add(int64(count))
+	c.system.totalReceived.Add(count)
+
+	if isEmpty {
+		m.emptyReceives.Add(1)
+	}
+
+	// Update in-flight count in store.
+	if c.store != nil {
+		_ = c.store.UpdateInFlightCount(context.Background(), queueID, m.messagesInFlight.Load())
+	}
+}
+
+// RecordDelete records a delete operation.
+func (c *Collector) RecordDelete(queueID string, count uint64, dwellTimeSeconds float64) {
+	m := c.getOrCreateQueueMetrics(queueID)
+	m.messagesDeleted.Add(count)
+	m.messagesInFlight.Add(-int64(count))
+	c.system.totalDeleted.Add(count)
+
+	// Record dwell time.
+	if dwellTimeSeconds > 0 {
+		m.histogramMu.Lock()
+		m.dwellTimes = append(m.dwellTimes, dwellTimeSeconds)
+		m.histogramMu.Unlock()
+	}
+
+	// Update in-flight count in store.
+	if c.store != nil {
+		_ = c.store.UpdateInFlightCount(context.Background(), queueID, m.messagesInFlight.Load())
+	}
+}
+
+// RecordRedelivery records a message redelivery.
+func (c *Collector) RecordRedelivery(queueID string, count uint64) {
+	m := c.getOrCreateQueueMetrics(queueID)
+	m.messagesRedelivered.Add(count)
+}
+
+// RecordDrop records dropped messages.
+func (c *Collector) RecordDrop(queueID string, count uint64) {
+	m := c.getOrCreateQueueMetrics(queueID)
+	m.messagesDropped.Add(count)
+}
+
+// RecordDLQ records messages moved to DLQ.
+func (c *Collector) RecordDLQ(queueID string, count uint64) {
+	m := c.getOrCreateQueueMetrics(queueID)
+	m.messagesToDLQ.Add(count)
+}
+
+// RecordBatchSize records a batch operation size.
+func (c *Collector) RecordBatchSize(queueID string, size int, operation string) {
+	m := c.getOrCreateQueueMetrics(queueID)
+	m.histogramMu.Lock()
+	m.batchSizes = append(m.batchSizes, size)
+	m.histogramMu.Unlock()
+}
+
+// RecordMessageSize records message body size.
+func (c *Collector) RecordMessageSize(queueID string, sizeBytes int) {
+	m := c.getOrCreateQueueMetrics(queueID)
+	m.histogramMu.Lock()
+	m.messageSizes = append(m.messageSizes, sizeBytes)
+	m.histogramMu.Unlock()
+}
+
+// RecordProcessingDuration records message processing duration.
+func (c *Collector) RecordProcessingDuration(queueID string, durationSeconds float64) {
+	m := c.getOrCreateQueueMetrics(queueID)
+	m.histogramMu.Lock()
+	m.processingDurations = append(m.processingDurations, durationSeconds)
+	m.histogramMu.Unlock()
+}
+
+// SetQueuesExist sets the current queue count.
+func (c *Collector) SetQueuesExist(count int64) {
+	c.system.queuesExist.Store(count)
+}
+
+// IncrementQueues increments the queue count.
+func (c *Collector) IncrementQueues() {
+	c.system.queuesExist.Add(1)
+}
+
+// DecrementQueues decrements the queue count.
+func (c *Collector) DecrementQueues() {
+	c.system.queuesExist.Add(-1)
+}
+
+// GetInFlightCount returns the current in-flight count for a queue.
+func (c *Collector) GetInFlightCount(queueID string) int64 {
+	m := c.getOrCreateQueueMetrics(queueID)
+	return m.messagesInFlight.Load()
+}
+
+// GetSystemInFlightCount returns total in-flight messages across all queues.
+func (c *Collector) GetSystemInFlightCount() int64 {
+	c.queueMu.RLock()
+	defer c.queueMu.RUnlock()
+
+	var total int64
+	for _, m := range c.queueMetrics {
+		total += m.messagesInFlight.Load()
+	}
+	return total
+}
+
+// GetRates returns current rates for a queue.
+func (c *Collector) GetRates(queueID string) (sendRate, receiveRate, deleteRate float64) {
+	m := c.getOrCreateQueueMetrics(queueID)
+	return float64FromBits(m.sendRate.Load()),
+		float64FromBits(m.receiveRate.Load()),
+		float64FromBits(m.deleteRate.Load())
+}
+
+// GetSystemRates returns system-wide rates.
+func (c *Collector) GetSystemRates() (sendRate, receiveRate, deleteRate float64) {
+	return float64FromBits(c.system.systemSendRate.Load()),
+		float64FromBits(c.system.systemReceiveRate.Load()),
+		float64FromBits(c.system.systemDeleteRate.Load())
+}
+
+// GetCounters returns current counter values for a queue.
+func (c *Collector) GetCounters(queueID string) map[string]uint64 {
+	m := c.getOrCreateQueueMetrics(queueID)
+	return map[string]uint64{
+		MetricMessagesSentTotal:     m.messagesSent.Load(),
+		MetricMessagesReceivedTotal: m.messagesReceived.Load(),
+		MetricMessagesDeletedTotal:  m.messagesDeleted.Load(),
+		MetricMessagesDroppedTotal:  m.messagesDropped.Load(),
+		MetricEmptyReceivesTotal:    m.emptyReceives.Load(),
+		MetricMessagesRedelivered:   m.messagesRedelivered.Load(),
+		MetricMessagesToDLQ:         m.messagesToDLQ.Load(),
+		MetricBytesSentTotal:        m.bytesSent.Load(),
+	}
+}
+
+// GetAllQueueIDs returns all tracked queue IDs.
+func (c *Collector) GetAllQueueIDs() []string {
+	c.queueMu.RLock()
+	defer c.queueMu.RUnlock()
+
+	ids := make([]string, 0, len(c.queueMetrics))
+	for id := range c.queueMetrics {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// rateCalculationWorker calculates rates periodically.
+func (c *Collector) rateCalculationWorker(ctx context.Context) {
+	ticker := time.NewTicker(c.collectionInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-c.stop:
+			return
+		case <-ticker.C:
+			c.calculateRates()
+		}
+	}
+}
+
+// calculateRates calculates rates for all queues.
+func (c *Collector) calculateRates() {
+	now := time.Now().UnixMilli()
+
+	c.queueMu.RLock()
+	defer c.queueMu.RUnlock()
+
+	for queueID, m := range c.queueMetrics {
+		currentSent := m.messagesSent.Load()
+		currentReceived := m.messagesReceived.Load()
+		currentDeleted := m.messagesDeleted.Load()
+
+		// Calculate rates.
+		sendRate := float64(currentSent - m.prevSent)
+		receiveRate := float64(currentReceived - m.prevReceived)
+		deleteRate := float64(currentDeleted - m.prevDeleted)
+
+		// Store rates atomically.
+		m.sendRate.Store(float64ToBits(sendRate))
+		m.receiveRate.Store(float64ToBits(receiveRate))
+		m.deleteRate.Store(float64ToBits(deleteRate))
+
+		// Update previous values.
+		m.prevSent = currentSent
+		m.prevReceived = currentReceived
+		m.prevDeleted = currentDeleted
+
+		// Persist rates to store.
+		if c.store != nil {
+			_ = c.store.SaveRateSnapshot(context.Background(), now, queueID, MetricSendRate, sendRate, 1)
+			_ = c.store.SaveRateSnapshot(context.Background(), now, queueID, MetricReceiveRate, receiveRate, 1)
+			_ = c.store.SaveRateSnapshot(context.Background(), now, queueID, MetricDeleteRate, deleteRate, 1)
+
+			// Also save raw metric values.
+			_ = c.store.SaveRawMetric(context.Background(), now, queueID, MetricMessagesSentTotal, float64(currentSent), "")
+			_ = c.store.SaveRawMetric(context.Background(), now, queueID, MetricMessagesReceivedTotal, float64(currentReceived), "")
+			_ = c.store.SaveRawMetric(context.Background(), now, queueID, MetricMessagesDeletedTotal, float64(currentDeleted), "")
+			_ = c.store.SaveRawMetric(context.Background(), now, queueID, MetricMessagesInFlight, float64(m.messagesInFlight.Load()), "")
+		}
+	}
+
+	// Calculate system-wide rates.
+	currentTotalSent := c.system.totalSent.Load()
+	currentTotalReceived := c.system.totalReceived.Load()
+	currentTotalDeleted := c.system.totalDeleted.Load()
+
+	systemSendRate := float64(currentTotalSent - c.system.prevTotalSent)
+	systemReceiveRate := float64(currentTotalReceived - c.system.prevTotalReceived)
+	systemDeleteRate := float64(currentTotalDeleted - c.system.prevTotalDeleted)
+
+	c.system.systemSendRate.Store(float64ToBits(systemSendRate))
+	c.system.systemReceiveRate.Store(float64ToBits(systemReceiveRate))
+	c.system.systemDeleteRate.Store(float64ToBits(systemDeleteRate))
+
+	c.system.prevTotalSent = currentTotalSent
+	c.system.prevTotalReceived = currentTotalReceived
+	c.system.prevTotalDeleted = currentTotalDeleted
+
+	// Persist system-wide metrics.
+	if c.store != nil {
+		_ = c.store.SaveRateSnapshot(context.Background(), now, "", MetricSendRate, systemSendRate, 1)
+		_ = c.store.SaveRateSnapshot(context.Background(), now, "", MetricReceiveRate, systemReceiveRate, 1)
+		_ = c.store.SaveRateSnapshot(context.Background(), now, "", MetricDeleteRate, systemDeleteRate, 1)
+		_ = c.store.SaveRawMetric(context.Background(), now, "", MetricQueuesExist, float64(c.system.queuesExist.Load()), "")
+	}
+}
+
+// aggregationWorker runs periodic aggregation.
+func (c *Collector) aggregationWorker(ctx context.Context, interval time.Duration, name string, aggregateFn func(context.Context) error) {
+	// Align to interval boundary.
+	now := time.Now()
+	nextRun := now.Truncate(interval).Add(interval)
+	time.Sleep(nextRun.Sub(now))
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-c.stop:
+			return
+		case <-ticker.C:
+			if err := aggregateFn(ctx); err != nil {
+				c.logger.Error("Aggregation failed",
+					slog.String("interval", name),
+					slog.String("error", err.Error()),
+				)
+			}
+		}
+	}
+}
+
+func (c *Collector) aggregate1m(ctx context.Context) error {
+	if c.store == nil {
+		return nil
+	}
+	now := time.Now().UnixMilli()
+	from := now - int64(aggregationInterval1m.Milliseconds()) - 1000 // 1 extra second buffer
+	return c.store.Aggregate1m(ctx, from, now)
+}
+
+func (c *Collector) aggregate1h(ctx context.Context) error {
+	if c.store == nil {
+		return nil
+	}
+	now := time.Now().UnixMilli()
+	from := now - int64(aggregationInterval1h.Milliseconds()) - 60000 // 1 extra minute buffer
+	return c.store.Aggregate1h(ctx, from, now)
+}
+
+func (c *Collector) aggregate1d(ctx context.Context) error {
+	if c.store == nil {
+		return nil
+	}
+	now := time.Now().UnixMilli()
+	from := now - int64(aggregationInterval1d.Milliseconds()) - 3600000 // 1 extra hour buffer
+	return c.store.Aggregate1d(ctx, from, now)
+}
+
+// cleanupWorker runs periodic cleanup of old metrics.
+func (c *Collector) cleanupWorker(ctx context.Context) {
+	ticker := time.NewTicker(10 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-c.stop:
+			return
+		case <-ticker.C:
+			if c.store != nil {
+				now := time.Now().UnixMilli()
+				err := c.store.CleanupOldMetrics(ctx,
+					now-int64(retentionRaw.Milliseconds()),
+					now-int64(retention1m.Milliseconds()),
+					now-int64(retention5m.Milliseconds()),
+					now-int64(retention1h.Milliseconds()),
+					now-int64(retention1d.Milliseconds()),
+				)
+				if err != nil {
+					c.logger.Error("Metrics cleanup failed", slog.String("error", err.Error()))
+				}
+			}
+		}
+	}
+}
+
+// Helper functions for atomic float64 operations.
+func float64ToBits(f float64) uint64 {
+	return *(*uint64)((*[8]byte)((*[8]byte)(&f))[:])
+}
+
+func float64FromBits(b uint64) float64 {
+	return *(*float64)((*[8]byte)((*[8]byte)(&b))[:])
+}

--- a/internal/server/telemetry/collector/collector.go
+++ b/internal/server/telemetry/collector/collector.go
@@ -6,6 +6,7 @@ package collector
 import (
 	"context"
 	"log/slog"
+	"math"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -80,15 +81,15 @@ const (
 // QueueMetrics holds metrics for a specific queue.
 type QueueMetrics struct {
 	// Counters (atomic for thread safety).
-	messagesSent     atomic.Uint64
-	messagesReceived atomic.Uint64
-	messagesDeleted  atomic.Uint64
-	messagesDropped  atomic.Uint64
-	emptyReceives    atomic.Uint64
+	messagesSent        atomic.Uint64
+	messagesReceived    atomic.Uint64
+	messagesDeleted     atomic.Uint64
+	messagesDropped     atomic.Uint64
+	emptyReceives       atomic.Uint64
 	messagesRedelivered atomic.Uint64
-	messagesToDLQ    atomic.Uint64
-	bytesSent        atomic.Uint64
-	bytesReceived    atomic.Uint64
+	messagesToDLQ       atomic.Uint64
+	bytesSent           atomic.Uint64
+	bytesReceived       atomic.Uint64
 
 	// In-flight tracking.
 	messagesInFlight atomic.Int64
@@ -202,12 +203,12 @@ type DataPoint struct {
 
 // QueueStatsPoint represents queue statistics at a point in time.
 type QueueStatsPoint struct {
-	Timestamp        int64   `json:"timestamp"`
-	QueueDepth       int64   `json:"queueDepth"`
-	MessagesVisible  int64   `json:"messagesVisible"`
-	MessagesInvisible int64  `json:"messagesInvisible"`
-	OldestMessageAge float64 `json:"oldestMessageAge"`
-	AvgMessageAge    float64 `json:"avgMessageAge"`
+	Timestamp         int64   `json:"timestamp"`
+	QueueDepth        int64   `json:"queueDepth"`
+	MessagesVisible   int64   `json:"messagesVisible"`
+	MessagesInvisible int64   `json:"messagesInvisible"`
+	OldestMessageAge  float64 `json:"oldestMessageAge"`
+	AvgMessageAge     float64 `json:"avgMessageAge"`
 }
 
 // Option configures the Collector.
@@ -629,9 +630,9 @@ func (c *Collector) cleanupWorker(ctx context.Context) {
 
 // Helper functions for atomic float64 operations.
 func float64ToBits(f float64) uint64 {
-	return *(*uint64)((*[8]byte)((*[8]byte)(&f))[:])
+	return math.Float64bits(f)
 }
 
 func float64FromBits(b uint64) float64 {
-	return *(*float64)((*[8]byte)((*[8]byte)(&b))[:])
+	return math.Float64frombits(b)
 }

--- a/internal/server/telemetry/collector/store.go
+++ b/internal/server/telemetry/collector/store.go
@@ -154,7 +154,7 @@ func (s *SQLiteStore) CleanupOldMetrics(ctx context.Context, rawBefore, m1Before
 
 // GetMetrics retrieves metrics for a time range.
 // resolution: "raw", "1m", "5m", "1h", "1d".
-// When queueID is empty, returns system-wide metrics (queue_id = '').
+// When queueID is empty, returns system-wide metrics (queue_id = ”).
 func (s *SQLiteStore) GetMetrics(ctx context.Context, metricName, queueID string, from, to int64, resolution string) ([]DataPoint, error) {
 	var query string
 	var args []interface{}
@@ -294,7 +294,7 @@ func (s *SQLiteStore) GetInFlightCounts(ctx context.Context) (map[string]int64, 
 }
 
 // GetRateHistory retrieves rate history for a metric.
-// When queueID is empty, returns system-wide metrics (queue_id = '').
+// When queueID is empty, returns system-wide metrics (queue_id = ”).
 func (s *SQLiteStore) GetRateHistory(ctx context.Context, metricName, queueID string, from, to int64) ([]DataPoint, error) {
 	// Always filter by queue_id - empty string means system-wide metrics.
 	query := `
@@ -323,7 +323,7 @@ func (s *SQLiteStore) GetRateHistory(ctx context.Context, metricName, queueID st
 	return points, rows.Err()
 }
 
-// GetSystemMetrics retrieves system-wide metrics (queue_id = '').
+// GetSystemMetrics retrieves system-wide metrics (queue_id = ”).
 func (s *SQLiteStore) GetSystemMetrics(ctx context.Context, metricName string, from, to int64, resolution string) ([]DataPoint, error) {
 	return s.GetMetrics(ctx, metricName, "", from, to, resolution)
 }

--- a/internal/server/telemetry/collector/store.go
+++ b/internal/server/telemetry/collector/store.go
@@ -1,0 +1,463 @@
+package collector
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/plainq/servekit/dbkit/litekit"
+)
+
+// SQLiteStore implements the Store interface using SQLite.
+type SQLiteStore struct {
+	db *litekit.Conn
+}
+
+// NewSQLiteStore creates a new SQLite-backed metrics store.
+func NewSQLiteStore(db *litekit.Conn) *SQLiteStore {
+	return &SQLiteStore{db: db}
+}
+
+// SaveRawMetric saves a raw metric data point.
+func (s *SQLiteStore) SaveRawMetric(ctx context.Context, timestamp int64, queueID, metricName string, value float64, labels string) error {
+	query := `INSERT INTO metrics_raw (timestamp, queue_id, metric_name, metric_value, labels) VALUES (?, ?, ?, ?, ?)`
+	_, err := s.db.ExecContext(ctx, query, timestamp, queueID, metricName, value, labels)
+	return err
+}
+
+// SaveRateSnapshot saves rate calculation results.
+func (s *SQLiteStore) SaveRateSnapshot(ctx context.Context, timestamp int64, queueID, metricName string, ratePerSecond float64, windowSeconds int) error {
+	query := `INSERT INTO rate_snapshots (timestamp, queue_id, metric_name, rate_per_second, window_seconds) VALUES (?, ?, ?, ?, ?)`
+	_, err := s.db.ExecContext(ctx, query, timestamp, queueID, metricName, ratePerSecond, windowSeconds)
+	return err
+}
+
+// SaveQueueStats saves queue statistics snapshot.
+func (s *SQLiteStore) SaveQueueStats(ctx context.Context, timestamp int64, queueID string, depth, visible, invisible int64, oldestAge, avgAge float64) error {
+	query := `INSERT INTO queue_stats_snapshot (timestamp, queue_id, queue_depth, messages_visible, messages_invisible, oldest_message_age_seconds, avg_message_age_seconds) VALUES (?, ?, ?, ?, ?, ?, ?)`
+	_, err := s.db.ExecContext(ctx, query, timestamp, queueID, depth, visible, invisible, oldestAge, avgAge)
+	return err
+}
+
+// UpdateInFlightCount updates the in-flight message count for a queue.
+func (s *SQLiteStore) UpdateInFlightCount(ctx context.Context, queueID string, count int64) error {
+	query := `INSERT INTO messages_in_flight (queue_id, count, updated_at) VALUES (?, ?, ?)
+		ON CONFLICT(queue_id) DO UPDATE SET count = excluded.count, updated_at = excluded.updated_at`
+	_, err := s.db.ExecContext(ctx, query, queueID, count, time.Now().UnixMilli())
+	return err
+}
+
+// Aggregate1m aggregates raw metrics into 1-minute buckets.
+func (s *SQLiteStore) Aggregate1m(ctx context.Context, fromTimestamp, toTimestamp int64) error {
+	// Calculate bucket boundaries (1-minute = 60000ms).
+	bucketSize := int64(60000)
+
+	query := `
+		INSERT OR REPLACE INTO metrics_1m (bucket_start, queue_id, metric_name, min_value, max_value, avg_value, sum_value, count, labels)
+		SELECT
+			(timestamp / ?) * ? as bucket_start,
+			queue_id,
+			metric_name,
+			MIN(metric_value) as min_value,
+			MAX(metric_value) as max_value,
+			AVG(metric_value) as avg_value,
+			SUM(metric_value) as sum_value,
+			COUNT(*) as count,
+			labels
+		FROM metrics_raw
+		WHERE timestamp >= ? AND timestamp < ?
+		GROUP BY bucket_start, queue_id, metric_name, labels
+	`
+	_, err := s.db.ExecContext(ctx, query, bucketSize, bucketSize, fromTimestamp, toTimestamp)
+	return err
+}
+
+// Aggregate1h aggregates 1-minute metrics into 1-hour buckets.
+func (s *SQLiteStore) Aggregate1h(ctx context.Context, fromTimestamp, toTimestamp int64) error {
+	bucketSize := int64(3600000) // 1 hour in ms
+	minuteBucketSize := int64(60000)
+
+	query := `
+		INSERT OR REPLACE INTO metrics_1h (bucket_start, queue_id, metric_name, min_value, max_value, avg_value, sum_value, count, labels)
+		SELECT
+			(bucket_start / ?) * ? as hour_bucket,
+			queue_id,
+			metric_name,
+			MIN(min_value) as min_value,
+			MAX(max_value) as max_value,
+			SUM(avg_value * count) / SUM(count) as avg_value,
+			SUM(sum_value) as sum_value,
+			SUM(count) as count,
+			labels
+		FROM metrics_1m
+		WHERE bucket_start >= (? / ?) * ? AND bucket_start < (? / ?) * ?
+		GROUP BY hour_bucket, queue_id, metric_name, labels
+	`
+	_, err := s.db.ExecContext(ctx, query,
+		bucketSize, bucketSize,
+		fromTimestamp, minuteBucketSize, minuteBucketSize,
+		toTimestamp, minuteBucketSize, minuteBucketSize)
+	return err
+}
+
+// Aggregate1d aggregates 1-hour metrics into 1-day buckets.
+func (s *SQLiteStore) Aggregate1d(ctx context.Context, fromTimestamp, toTimestamp int64) error {
+	bucketSize := int64(86400000) // 1 day in ms
+	hourBucketSize := int64(3600000)
+
+	query := `
+		INSERT OR REPLACE INTO metrics_1d (bucket_start, queue_id, metric_name, min_value, max_value, avg_value, sum_value, count, labels)
+		SELECT
+			(bucket_start / ?) * ? as day_bucket,
+			queue_id,
+			metric_name,
+			MIN(min_value) as min_value,
+			MAX(max_value) as max_value,
+			SUM(avg_value * count) / SUM(count) as avg_value,
+			SUM(sum_value) as sum_value,
+			SUM(count) as count,
+			labels
+		FROM metrics_1h
+		WHERE bucket_start >= (? / ?) * ? AND bucket_start < (? / ?) * ?
+		GROUP BY day_bucket, queue_id, metric_name, labels
+	`
+	_, err := s.db.ExecContext(ctx, query,
+		bucketSize, bucketSize,
+		fromTimestamp, hourBucketSize, hourBucketSize,
+		toTimestamp, hourBucketSize, hourBucketSize)
+	return err
+}
+
+// CleanupOldMetrics removes metrics older than retention period.
+func (s *SQLiteStore) CleanupOldMetrics(ctx context.Context, rawBefore, m1Before, m5Before, h1Before, d1Before int64) error {
+	queries := []string{
+		`DELETE FROM metrics_raw WHERE timestamp < ?`,
+		`DELETE FROM metrics_1m WHERE bucket_start < ?`,
+		`DELETE FROM metrics_5m WHERE timestamp < ?`,
+		`DELETE FROM metrics_1h WHERE bucket_start < ?`,
+		`DELETE FROM metrics_1d WHERE bucket_start < ?`,
+		`DELETE FROM rate_snapshots WHERE timestamp < ?`,
+		`DELETE FROM queue_stats_snapshot WHERE timestamp < ?`,
+	}
+
+	thresholds := []int64{rawBefore, m1Before, m5Before, h1Before, d1Before, rawBefore, rawBefore}
+
+	for i, query := range queries {
+		if _, err := s.db.ExecContext(ctx, query, thresholds[i]); err != nil {
+			return fmt.Errorf("cleanup query %d: %w", i, err)
+		}
+	}
+
+	return nil
+}
+
+// GetMetrics retrieves metrics for a time range.
+// resolution: "raw", "1m", "5m", "1h", "1d".
+func (s *SQLiteStore) GetMetrics(ctx context.Context, metricName, queueID string, from, to int64, resolution string) ([]DataPoint, error) {
+	var query string
+	var args []interface{}
+
+	switch resolution {
+	case "raw":
+		query = `SELECT timestamp, metric_value, metric_value, metric_value, metric_value, metric_value, 1
+			FROM metrics_raw WHERE metric_name = ? AND timestamp >= ? AND timestamp <= ?`
+		args = []interface{}{metricName, from, to}
+		if queueID != "" {
+			query = `SELECT timestamp, metric_value, metric_value, metric_value, metric_value, metric_value, 1
+				FROM metrics_raw WHERE metric_name = ? AND queue_id = ? AND timestamp >= ? AND timestamp <= ?`
+			args = []interface{}{metricName, queueID, from, to}
+		}
+		query += " ORDER BY timestamp ASC"
+
+	case "1m":
+		query = `SELECT bucket_start, avg_value, min_value, max_value, avg_value, sum_value, count
+			FROM metrics_1m WHERE metric_name = ? AND bucket_start >= ? AND bucket_start <= ?`
+		args = []interface{}{metricName, from, to}
+		if queueID != "" {
+			query = `SELECT bucket_start, avg_value, min_value, max_value, avg_value, sum_value, count
+				FROM metrics_1m WHERE metric_name = ? AND queue_id = ? AND bucket_start >= ? AND bucket_start <= ?`
+			args = []interface{}{metricName, queueID, from, to}
+		}
+		query += " ORDER BY bucket_start ASC"
+
+	case "5m":
+		query = `SELECT timestamp, metric_value_avg, metric_value_min, metric_value_max, metric_value_avg, metric_value_avg, 1
+			FROM metrics_5m WHERE metric_name = ? AND timestamp >= ? AND timestamp <= ?`
+		args = []interface{}{metricName, from, to}
+		if queueID != "" {
+			query = `SELECT timestamp, metric_value_avg, metric_value_min, metric_value_max, metric_value_avg, metric_value_avg, 1
+				FROM metrics_5m WHERE metric_name = ? AND queue_id = ? AND timestamp >= ? AND timestamp <= ?`
+			args = []interface{}{metricName, queueID, from, to}
+		}
+		query += " ORDER BY timestamp ASC"
+
+	case "1h":
+		query = `SELECT bucket_start, avg_value, min_value, max_value, avg_value, sum_value, count
+			FROM metrics_1h WHERE metric_name = ? AND bucket_start >= ? AND bucket_start <= ?`
+		args = []interface{}{metricName, from, to}
+		if queueID != "" {
+			query = `SELECT bucket_start, avg_value, min_value, max_value, avg_value, sum_value, count
+				FROM metrics_1h WHERE metric_name = ? AND queue_id = ? AND bucket_start >= ? AND bucket_start <= ?`
+			args = []interface{}{metricName, queueID, from, to}
+		}
+		query += " ORDER BY bucket_start ASC"
+
+	case "1d":
+		query = `SELECT bucket_start, avg_value, min_value, max_value, avg_value, sum_value, count
+			FROM metrics_1d WHERE metric_name = ? AND bucket_start >= ? AND bucket_start <= ?`
+		args = []interface{}{metricName, from, to}
+		if queueID != "" {
+			query = `SELECT bucket_start, avg_value, min_value, max_value, avg_value, sum_value, count
+				FROM metrics_1d WHERE metric_name = ? AND queue_id = ? AND bucket_start >= ? AND bucket_start <= ?`
+			args = []interface{}{metricName, queueID, from, to}
+		}
+		query += " ORDER BY bucket_start ASC"
+
+	default:
+		return nil, fmt.Errorf("unknown resolution: %s", resolution)
+	}
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query metrics: %w", err)
+	}
+	defer rows.Close()
+
+	var points []DataPoint
+	for rows.Next() {
+		var p DataPoint
+		if err := rows.Scan(&p.Timestamp, &p.Value, &p.Min, &p.Max, &p.Avg, &p.Sum, &p.Count); err != nil {
+			return nil, fmt.Errorf("scan row: %w", err)
+		}
+		points = append(points, p)
+	}
+
+	return points, rows.Err()
+}
+
+// GetLatestRates retrieves the latest rate values.
+func (s *SQLiteStore) GetLatestRates(ctx context.Context, queueID string) (map[string]float64, error) {
+	query := `
+		SELECT metric_name, rate_per_second
+		FROM rate_snapshots
+		WHERE queue_id = ? AND timestamp = (
+			SELECT MAX(timestamp) FROM rate_snapshots WHERE queue_id = ?
+		)
+	`
+
+	rows, err := s.db.QueryContext(ctx, query, queueID, queueID)
+	if err != nil {
+		return nil, fmt.Errorf("query rates: %w", err)
+	}
+	defer rows.Close()
+
+	rates := make(map[string]float64)
+	for rows.Next() {
+		var name string
+		var rate float64
+		if err := rows.Scan(&name, &rate); err != nil {
+			return nil, fmt.Errorf("scan row: %w", err)
+		}
+		rates[name] = rate
+	}
+
+	return rates, rows.Err()
+}
+
+// GetQueueStats retrieves queue statistics.
+func (s *SQLiteStore) GetQueueStats(ctx context.Context, queueID string, from, to int64) ([]QueueStatsPoint, error) {
+	query := `
+		SELECT timestamp, queue_depth, messages_visible, messages_invisible,
+			oldest_message_age_seconds, avg_message_age_seconds
+		FROM queue_stats_snapshot
+		WHERE queue_id = ? AND timestamp >= ? AND timestamp <= ?
+		ORDER BY timestamp ASC
+	`
+
+	rows, err := s.db.QueryContext(ctx, query, queueID, from, to)
+	if err != nil {
+		return nil, fmt.Errorf("query queue stats: %w", err)
+	}
+	defer rows.Close()
+
+	var points []QueueStatsPoint
+	for rows.Next() {
+		var p QueueStatsPoint
+		if err := rows.Scan(&p.Timestamp, &p.QueueDepth, &p.MessagesVisible, &p.MessagesInvisible, &p.OldestMessageAge, &p.AvgMessageAge); err != nil {
+			return nil, fmt.Errorf("scan row: %w", err)
+		}
+		points = append(points, p)
+	}
+
+	return points, rows.Err()
+}
+
+// GetInFlightCounts retrieves in-flight counts for all queues.
+func (s *SQLiteStore) GetInFlightCounts(ctx context.Context) (map[string]int64, error) {
+	query := `SELECT queue_id, count FROM messages_in_flight`
+
+	rows, err := s.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("query in-flight: %w", err)
+	}
+	defer rows.Close()
+
+	counts := make(map[string]int64)
+	for rows.Next() {
+		var queueID string
+		var count int64
+		if err := rows.Scan(&queueID, &count); err != nil {
+			return nil, fmt.Errorf("scan row: %w", err)
+		}
+		counts[queueID] = count
+	}
+
+	return counts, rows.Err()
+}
+
+// GetRateHistory retrieves rate history for a metric.
+func (s *SQLiteStore) GetRateHistory(ctx context.Context, metricName, queueID string, from, to int64) ([]DataPoint, error) {
+	query := `
+		SELECT timestamp, rate_per_second, rate_per_second, rate_per_second, rate_per_second, rate_per_second, 1
+		FROM rate_snapshots
+		WHERE metric_name = ? AND timestamp >= ? AND timestamp <= ?
+	`
+	args := []interface{}{metricName, from, to}
+
+	if queueID != "" {
+		query = `
+			SELECT timestamp, rate_per_second, rate_per_second, rate_per_second, rate_per_second, rate_per_second, 1
+			FROM rate_snapshots
+			WHERE metric_name = ? AND queue_id = ? AND timestamp >= ? AND timestamp <= ?
+		`
+		args = []interface{}{metricName, queueID, from, to}
+	}
+	query += " ORDER BY timestamp ASC"
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query rate history: %w", err)
+	}
+	defer rows.Close()
+
+	var points []DataPoint
+	for rows.Next() {
+		var p DataPoint
+		if err := rows.Scan(&p.Timestamp, &p.Value, &p.Min, &p.Max, &p.Avg, &p.Sum, &p.Count); err != nil {
+			return nil, fmt.Errorf("scan row: %w", err)
+		}
+		points = append(points, p)
+	}
+
+	return points, rows.Err()
+}
+
+// GetSystemMetrics retrieves system-wide metrics (queue_id = '').
+func (s *SQLiteStore) GetSystemMetrics(ctx context.Context, metricName string, from, to int64, resolution string) ([]DataPoint, error) {
+	return s.GetMetrics(ctx, metricName, "", from, to, resolution)
+}
+
+// GetAllQueuesMetrics retrieves metrics aggregated across all queues.
+func (s *SQLiteStore) GetAllQueuesMetrics(ctx context.Context, metricName string, from, to int64) ([]DataPoint, error) {
+	query := `
+		SELECT timestamp, SUM(metric_value) as value
+		FROM metrics_raw
+		WHERE metric_name = ? AND timestamp >= ? AND timestamp <= ? AND queue_id != ''
+		GROUP BY timestamp
+		ORDER BY timestamp ASC
+	`
+
+	rows, err := s.db.QueryContext(ctx, query, metricName, from, to)
+	if err != nil {
+		return nil, fmt.Errorf("query all queues metrics: %w", err)
+	}
+	defer rows.Close()
+
+	var points []DataPoint
+	for rows.Next() {
+		var p DataPoint
+		if err := rows.Scan(&p.Timestamp, &p.Value); err != nil {
+			return nil, fmt.Errorf("scan row: %w", err)
+		}
+		points = append(points, p)
+	}
+
+	return points, rows.Err()
+}
+
+// GetLatestMetricValue retrieves the most recent value for a metric.
+func (s *SQLiteStore) GetLatestMetricValue(ctx context.Context, metricName, queueID string) (float64, int64, error) {
+	query := `
+		SELECT metric_value, timestamp
+		FROM metrics_raw
+		WHERE metric_name = ? AND queue_id = ?
+		ORDER BY timestamp DESC
+		LIMIT 1
+	`
+
+	var value float64
+	var timestamp int64
+	err := s.db.QueryRowContext(ctx, query, metricName, queueID).Scan(&value, &timestamp)
+	if err == sql.ErrNoRows {
+		return 0, 0, nil
+	}
+	if err != nil {
+		return 0, 0, fmt.Errorf("query latest metric: %w", err)
+	}
+
+	return value, timestamp, nil
+}
+
+// GetMetricsSummary retrieves a summary of metrics for a time range.
+func (s *SQLiteStore) GetMetricsSummary(ctx context.Context, queueID string, from, to int64) (*MetricsSummary, error) {
+	summary := &MetricsSummary{
+		QueueID: queueID,
+		From:    from,
+		To:      to,
+	}
+
+	// Get total sent.
+	query := `SELECT COALESCE(MAX(metric_value) - MIN(metric_value), 0) FROM metrics_raw WHERE metric_name = ? AND queue_id = ? AND timestamp >= ? AND timestamp <= ?`
+	_ = s.db.QueryRowContext(ctx, query, MetricMessagesSentTotal, queueID, from, to).Scan(&summary.TotalSent)
+
+	// Get total received.
+	_ = s.db.QueryRowContext(ctx, query, MetricMessagesReceivedTotal, queueID, from, to).Scan(&summary.TotalReceived)
+
+	// Get total deleted.
+	_ = s.db.QueryRowContext(ctx, query, MetricMessagesDeletedTotal, queueID, from, to).Scan(&summary.TotalDeleted)
+
+	// Get average rates.
+	rateQuery := `SELECT COALESCE(AVG(rate_per_second), 0) FROM rate_snapshots WHERE metric_name = ? AND queue_id = ? AND timestamp >= ? AND timestamp <= ?`
+	_ = s.db.QueryRowContext(ctx, rateQuery, MetricSendRate, queueID, from, to).Scan(&summary.AvgSendRate)
+	_ = s.db.QueryRowContext(ctx, rateQuery, MetricReceiveRate, queueID, from, to).Scan(&summary.AvgReceiveRate)
+	_ = s.db.QueryRowContext(ctx, rateQuery, MetricDeleteRate, queueID, from, to).Scan(&summary.AvgDeleteRate)
+
+	// Get max rates.
+	maxRateQuery := `SELECT COALESCE(MAX(rate_per_second), 0) FROM rate_snapshots WHERE metric_name = ? AND queue_id = ? AND timestamp >= ? AND timestamp <= ?`
+	_ = s.db.QueryRowContext(ctx, maxRateQuery, MetricSendRate, queueID, from, to).Scan(&summary.MaxSendRate)
+	_ = s.db.QueryRowContext(ctx, maxRateQuery, MetricReceiveRate, queueID, from, to).Scan(&summary.MaxReceiveRate)
+	_ = s.db.QueryRowContext(ctx, maxRateQuery, MetricDeleteRate, queueID, from, to).Scan(&summary.MaxDeleteRate)
+
+	// Get current in-flight.
+	_ = s.db.QueryRowContext(ctx, `SELECT COALESCE(count, 0) FROM messages_in_flight WHERE queue_id = ?`, queueID).Scan(&summary.CurrentInFlight)
+
+	return summary, nil
+}
+
+// MetricsSummary contains aggregated metrics summary.
+type MetricsSummary struct {
+	QueueID         string  `json:"queueId"`
+	From            int64   `json:"from"`
+	To              int64   `json:"to"`
+	TotalSent       int64   `json:"totalSent"`
+	TotalReceived   int64   `json:"totalReceived"`
+	TotalDeleted    int64   `json:"totalDeleted"`
+	AvgSendRate     float64 `json:"avgSendRate"`
+	AvgReceiveRate  float64 `json:"avgReceiveRate"`
+	AvgDeleteRate   float64 `json:"avgDeleteRate"`
+	MaxSendRate     float64 `json:"maxSendRate"`
+	MaxReceiveRate  float64 `json:"maxReceiveRate"`
+	MaxDeleteRate   float64 `json:"maxDeleteRate"`
+	CurrentInFlight int64   `json:"currentInFlight"`
+}

--- a/internal/server/telemetry/prometheus.go
+++ b/internal/server/telemetry/prometheus.go
@@ -28,10 +28,10 @@ type PrometheusMetrics struct {
 	systemMessagesInFlight *metrics.Gauge
 
 	// Queue depth gauges.
-	queueDepth         map[string]*metrics.Gauge
-	messagesVisible    map[string]*metrics.Gauge
-	messagesInvisible  map[string]*metrics.Gauge
-	oldestMessageAge   map[string]*metrics.Gauge
+	queueDepth        map[string]*metrics.Gauge
+	messagesVisible   map[string]*metrics.Gauge
+	messagesInvisible map[string]*metrics.Gauge
+	oldestMessageAge  map[string]*metrics.Gauge
 
 	// Throughput gauges.
 	throughputIn  map[string]*metrics.Gauge
@@ -328,21 +328,21 @@ var observedMetricsEnhanced = map[string]struct{}{
 	"gc_duration":               {},
 
 	// New rate metrics.
-	"plainq_send_rate":                       {},
-	"plainq_receive_rate":                    {},
-	"plainq_delete_rate":                     {},
-	"plainq_system_send_rate":                {},
-	"plainq_system_receive_rate":             {},
-	"plainq_system_delete_rate":              {},
+	"plainq_send_rate":           {},
+	"plainq_receive_rate":        {},
+	"plainq_delete_rate":         {},
+	"plainq_system_send_rate":    {},
+	"plainq_system_receive_rate": {},
+	"plainq_system_delete_rate":  {},
 
 	// New gauge metrics.
-	"plainq_messages_in_flight":              {},
-	"plainq_system_messages_in_flight":       {},
-	"plainq_queue_depth":                     {},
-	"plainq_messages_visible":                {},
-	"plainq_messages_invisible":              {},
-	"plainq_oldest_message_age_seconds":      {},
-	"plainq_throughput_bytes_per_second":     {},
+	"plainq_messages_in_flight":          {},
+	"plainq_system_messages_in_flight":   {},
+	"plainq_queue_depth":                 {},
+	"plainq_messages_visible":            {},
+	"plainq_messages_invisible":          {},
+	"plainq_oldest_message_age_seconds":  {},
+	"plainq_throughput_bytes_per_second": {},
 
 	// New histogram metrics.
 	"plainq_message_processing_duration_seconds": {},
@@ -351,8 +351,8 @@ var observedMetricsEnhanced = map[string]struct{}{
 	"plainq_message_size_bytes":                  {},
 
 	// New counter metrics.
-	"plainq_messages_redelivered_total":      {},
-	"plainq_messages_to_dlq_total":           {},
+	"plainq_messages_redelivered_total": {},
+	"plainq_messages_to_dlq_total":      {},
 }
 
 // IsObservableEnhanced checks if a metric is observed (including new metrics).
@@ -364,10 +364,10 @@ func IsObservableEnhanced(metric string) bool {
 // EnhancedCounter wraps Counter with rate tracking capability.
 type EnhancedCounter struct {
 	Counter
-	lastValue    uint64
-	lastTime     time.Time
-	currentRate  float64
-	rateMu       sync.Mutex
+	lastValue   uint64
+	lastTime    time.Time
+	currentRate float64
+	rateMu      sync.Mutex
 }
 
 // NewEnhancedCounter wraps a Counter.

--- a/internal/server/telemetry/prometheus.go
+++ b/internal/server/telemetry/prometheus.go
@@ -1,0 +1,416 @@
+package telemetry
+
+import (
+	"math"
+	"sync"
+	"time"
+
+	"github.com/VictoriaMetrics/metrics"
+)
+
+// PrometheusMetrics provides enhanced Prometheus-compatible metrics.
+// This extends the existing observer with additional metrics for
+// comprehensive queue telemetry.
+type PrometheusMetrics struct {
+	// Rate gauges (calculated per second).
+	sendRates    map[string]*metrics.Gauge
+	receiveRates map[string]*metrics.Gauge
+	deleteRates  map[string]*metrics.Gauge
+	mu           sync.RWMutex
+
+	// System-wide rate gauges.
+	systemSendRate    *metrics.Gauge
+	systemReceiveRate *metrics.Gauge
+	systemDeleteRate  *metrics.Gauge
+
+	// In-flight gauges.
+	messagesInFlight       map[string]*metrics.Gauge
+	systemMessagesInFlight *metrics.Gauge
+
+	// Queue depth gauges.
+	queueDepth         map[string]*metrics.Gauge
+	messagesVisible    map[string]*metrics.Gauge
+	messagesInvisible  map[string]*metrics.Gauge
+	oldestMessageAge   map[string]*metrics.Gauge
+
+	// Throughput gauges.
+	throughputIn  map[string]*metrics.Gauge
+	throughputOut map[string]*metrics.Gauge
+
+	// Histogram metrics.
+	processingDuration map[string]*metrics.Histogram
+	dwellTime          map[string]*metrics.Histogram
+	batchSize          map[string]*metrics.Histogram
+	messageSize        map[string]*metrics.Histogram
+
+	// Additional counters.
+	messagesRedelivered map[string]*metrics.Counter
+	messagesToDLQ       map[string]*metrics.Counter
+}
+
+// NewPrometheusMetrics creates a new PrometheusMetrics instance.
+func NewPrometheusMetrics() *PrometheusMetrics {
+	pm := &PrometheusMetrics{
+		sendRates:           make(map[string]*metrics.Gauge),
+		receiveRates:        make(map[string]*metrics.Gauge),
+		deleteRates:         make(map[string]*metrics.Gauge),
+		messagesInFlight:    make(map[string]*metrics.Gauge),
+		queueDepth:          make(map[string]*metrics.Gauge),
+		messagesVisible:     make(map[string]*metrics.Gauge),
+		messagesInvisible:   make(map[string]*metrics.Gauge),
+		oldestMessageAge:    make(map[string]*metrics.Gauge),
+		throughputIn:        make(map[string]*metrics.Gauge),
+		throughputOut:       make(map[string]*metrics.Gauge),
+		processingDuration:  make(map[string]*metrics.Histogram),
+		dwellTime:           make(map[string]*metrics.Histogram),
+		batchSize:           make(map[string]*metrics.Histogram),
+		messageSize:         make(map[string]*metrics.Histogram),
+		messagesRedelivered: make(map[string]*metrics.Counter),
+		messagesToDLQ:       make(map[string]*metrics.Counter),
+	}
+
+	// Initialize system-wide gauges.
+	pm.systemSendRate = metrics.GetOrCreateGauge(`plainq_system_send_rate`, nil)
+	pm.systemReceiveRate = metrics.GetOrCreateGauge(`plainq_system_receive_rate`, nil)
+	pm.systemDeleteRate = metrics.GetOrCreateGauge(`plainq_system_delete_rate`, nil)
+	pm.systemMessagesInFlight = metrics.GetOrCreateGauge(`plainq_system_messages_in_flight`, nil)
+
+	return pm
+}
+
+// SetSendRate sets the send rate for a queue.
+func (pm *PrometheusMetrics) SetSendRate(queueID string, rate float64) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	gauge, ok := pm.sendRates[queueID]
+	if !ok {
+		gauge = metrics.GetOrCreateGauge(`plainq_send_rate{queue="`+queueID+`"}`, nil)
+		pm.sendRates[queueID] = gauge
+	}
+	gauge.Set(rate)
+}
+
+// SetReceiveRate sets the receive rate for a queue.
+func (pm *PrometheusMetrics) SetReceiveRate(queueID string, rate float64) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	gauge, ok := pm.receiveRates[queueID]
+	if !ok {
+		gauge = metrics.GetOrCreateGauge(`plainq_receive_rate{queue="`+queueID+`"}`, nil)
+		pm.receiveRates[queueID] = gauge
+	}
+	gauge.Set(rate)
+}
+
+// SetDeleteRate sets the delete rate for a queue.
+func (pm *PrometheusMetrics) SetDeleteRate(queueID string, rate float64) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	gauge, ok := pm.deleteRates[queueID]
+	if !ok {
+		gauge = metrics.GetOrCreateGauge(`plainq_delete_rate{queue="`+queueID+`"}`, nil)
+		pm.deleteRates[queueID] = gauge
+	}
+	gauge.Set(rate)
+}
+
+// SetSystemRates sets the system-wide rates.
+func (pm *PrometheusMetrics) SetSystemRates(sendRate, receiveRate, deleteRate float64) {
+	pm.systemSendRate.Set(sendRate)
+	pm.systemReceiveRate.Set(receiveRate)
+	pm.systemDeleteRate.Set(deleteRate)
+}
+
+// SetMessagesInFlight sets the in-flight message count for a queue.
+func (pm *PrometheusMetrics) SetMessagesInFlight(queueID string, count int64) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	gauge, ok := pm.messagesInFlight[queueID]
+	if !ok {
+		gauge = metrics.GetOrCreateGauge(`plainq_messages_in_flight{queue="`+queueID+`"}`, nil)
+		pm.messagesInFlight[queueID] = gauge
+	}
+	gauge.Set(float64(count))
+}
+
+// SetSystemMessagesInFlight sets the system-wide in-flight count.
+func (pm *PrometheusMetrics) SetSystemMessagesInFlight(count int64) {
+	pm.systemMessagesInFlight.Set(float64(count))
+}
+
+// SetQueueDepth sets the queue depth for a queue.
+func (pm *PrometheusMetrics) SetQueueDepth(queueID string, depth int64) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	gauge, ok := pm.queueDepth[queueID]
+	if !ok {
+		gauge = metrics.GetOrCreateGauge(`plainq_queue_depth{queue="`+queueID+`"}`, nil)
+		pm.queueDepth[queueID] = gauge
+	}
+	gauge.Set(float64(depth))
+}
+
+// SetMessagesVisible sets the visible message count for a queue.
+func (pm *PrometheusMetrics) SetMessagesVisible(queueID string, count int64) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	gauge, ok := pm.messagesVisible[queueID]
+	if !ok {
+		gauge = metrics.GetOrCreateGauge(`plainq_messages_visible{queue="`+queueID+`"}`, nil)
+		pm.messagesVisible[queueID] = gauge
+	}
+	gauge.Set(float64(count))
+}
+
+// SetMessagesInvisible sets the invisible message count for a queue.
+func (pm *PrometheusMetrics) SetMessagesInvisible(queueID string, count int64) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	gauge, ok := pm.messagesInvisible[queueID]
+	if !ok {
+		gauge = metrics.GetOrCreateGauge(`plainq_messages_invisible{queue="`+queueID+`"}`, nil)
+		pm.messagesInvisible[queueID] = gauge
+	}
+	gauge.Set(float64(count))
+}
+
+// SetOldestMessageAge sets the oldest message age for a queue.
+func (pm *PrometheusMetrics) SetOldestMessageAge(queueID string, ageSeconds float64) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	gauge, ok := pm.oldestMessageAge[queueID]
+	if !ok {
+		gauge = metrics.GetOrCreateGauge(`plainq_oldest_message_age_seconds{queue="`+queueID+`"}`, nil)
+		pm.oldestMessageAge[queueID] = gauge
+	}
+	gauge.Set(ageSeconds)
+}
+
+// SetThroughput sets the throughput for a queue.
+func (pm *PrometheusMetrics) SetThroughput(queueID string, bytesIn, bytesOut float64) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	gaugeIn, ok := pm.throughputIn[queueID]
+	if !ok {
+		gaugeIn = metrics.GetOrCreateGauge(`plainq_throughput_bytes_per_second{queue="`+queueID+`",direction="in"}`, nil)
+		pm.throughputIn[queueID] = gaugeIn
+	}
+	gaugeIn.Set(bytesIn)
+
+	gaugeOut, ok := pm.throughputOut[queueID]
+	if !ok {
+		gaugeOut = metrics.GetOrCreateGauge(`plainq_throughput_bytes_per_second{queue="`+queueID+`",direction="out"}`, nil)
+		pm.throughputOut[queueID] = gaugeOut
+	}
+	gaugeOut.Set(bytesOut)
+}
+
+// RecordProcessingDuration records a message processing duration.
+func (pm *PrometheusMetrics) RecordProcessingDuration(queueID string, durationSeconds float64) {
+	pm.mu.Lock()
+	hist, ok := pm.processingDuration[queueID]
+	if !ok {
+		hist = metrics.GetOrCreateHistogram(`plainq_message_processing_duration_seconds{queue="` + queueID + `"}`)
+		pm.processingDuration[queueID] = hist
+	}
+	pm.mu.Unlock()
+
+	hist.Update(durationSeconds)
+}
+
+// RecordDwellTime records message dwell time (time from send to receive).
+func (pm *PrometheusMetrics) RecordDwellTime(queueID string, durationSeconds float64) {
+	pm.mu.Lock()
+	hist, ok := pm.dwellTime[queueID]
+	if !ok {
+		hist = metrics.GetOrCreateHistogram(`plainq_message_dwell_time_seconds{queue="` + queueID + `"}`)
+		pm.dwellTime[queueID] = hist
+	}
+	pm.mu.Unlock()
+
+	hist.Update(durationSeconds)
+}
+
+// RecordBatchSize records a batch operation size.
+func (pm *PrometheusMetrics) RecordBatchSize(queueID string, size int, operation string) {
+	pm.mu.Lock()
+	key := queueID + "_" + operation
+	hist, ok := pm.batchSize[key]
+	if !ok {
+		hist = metrics.GetOrCreateHistogram(`plainq_batch_size{queue="` + queueID + `",operation="` + operation + `"}`)
+		pm.batchSize[key] = hist
+	}
+	pm.mu.Unlock()
+
+	hist.Update(float64(size))
+}
+
+// RecordMessageSize records a message body size.
+func (pm *PrometheusMetrics) RecordMessageSize(queueID string, sizeBytes int) {
+	pm.mu.Lock()
+	hist, ok := pm.messageSize[queueID]
+	if !ok {
+		hist = metrics.GetOrCreateHistogram(`plainq_message_size_bytes{queue="` + queueID + `"}`)
+		pm.messageSize[queueID] = hist
+	}
+	pm.mu.Unlock()
+
+	hist.Update(float64(sizeBytes))
+}
+
+// IncrementRedelivered increments the redelivery counter.
+func (pm *PrometheusMetrics) IncrementRedelivered(queueID string) {
+	pm.mu.Lock()
+	counter, ok := pm.messagesRedelivered[queueID]
+	if !ok {
+		counter = metrics.GetOrCreateCounter(`plainq_messages_redelivered_total{queue="` + queueID + `"}`)
+		pm.messagesRedelivered[queueID] = counter
+	}
+	pm.mu.Unlock()
+
+	counter.Inc()
+}
+
+// IncrementDLQ increments the DLQ counter.
+func (pm *PrometheusMetrics) IncrementDLQ(queueID string, sourceQueue string) {
+	pm.mu.Lock()
+	key := queueID + "_" + sourceQueue
+	counter, ok := pm.messagesToDLQ[key]
+	if !ok {
+		counter = metrics.GetOrCreateCounter(`plainq_messages_to_dlq_total{queue="` + queueID + `",source_queue="` + sourceQueue + `"}`)
+		pm.messagesToDLQ[key] = counter
+	}
+	pm.mu.Unlock()
+
+	counter.Inc()
+}
+
+// EnhancedObserver extends the base Observer with Prometheus metrics support.
+type EnhancedObserver struct {
+	*MetricsObserver
+	prom *PrometheusMetrics
+}
+
+// NewEnhancedObserver creates an EnhancedObserver with Prometheus metrics.
+func NewEnhancedObserver() *EnhancedObserver {
+	return &EnhancedObserver{
+		MetricsObserver: NewObserver(),
+		prom:            NewPrometheusMetrics(),
+	}
+}
+
+// Prometheus returns the Prometheus metrics instance.
+func (e *EnhancedObserver) Prometheus() *PrometheusMetrics {
+	return e.prom
+}
+
+// observedMetricsEnhanced is the full list of observed metrics including new ones.
+var observedMetricsEnhanced = map[string]struct{}{
+	// Original metrics.
+	"queues_exist":              {},
+	"message_in_queue_duration": {},
+	"messages_sent_total":       {},
+	"messages_sent_bytes_total": {},
+	"messages_received_total":   {},
+	"messages_deleted_total":    {},
+	"messages_dropped_total":    {},
+	"empty_receives_total":      {},
+	"gc_schedules_total":        {},
+	"gc_duration":               {},
+
+	// New rate metrics.
+	"plainq_send_rate":                       {},
+	"plainq_receive_rate":                    {},
+	"plainq_delete_rate":                     {},
+	"plainq_system_send_rate":                {},
+	"plainq_system_receive_rate":             {},
+	"plainq_system_delete_rate":              {},
+
+	// New gauge metrics.
+	"plainq_messages_in_flight":              {},
+	"plainq_system_messages_in_flight":       {},
+	"plainq_queue_depth":                     {},
+	"plainq_messages_visible":                {},
+	"plainq_messages_invisible":              {},
+	"plainq_oldest_message_age_seconds":      {},
+	"plainq_throughput_bytes_per_second":     {},
+
+	// New histogram metrics.
+	"plainq_message_processing_duration_seconds": {},
+	"plainq_message_dwell_time_seconds":          {},
+	"plainq_batch_size":                          {},
+	"plainq_message_size_bytes":                  {},
+
+	// New counter metrics.
+	"plainq_messages_redelivered_total":      {},
+	"plainq_messages_to_dlq_total":           {},
+}
+
+// IsObservableEnhanced checks if a metric is observed (including new metrics).
+func IsObservableEnhanced(metric string) bool {
+	_, ok := observedMetricsEnhanced[metric]
+	return ok
+}
+
+// EnhancedCounter wraps Counter with rate tracking capability.
+type EnhancedCounter struct {
+	Counter
+	lastValue    uint64
+	lastTime     time.Time
+	currentRate  float64
+	rateMu       sync.Mutex
+}
+
+// NewEnhancedCounter wraps a Counter.
+func NewEnhancedCounter(c Counter) *EnhancedCounter {
+	return &EnhancedCounter{
+		Counter:  c,
+		lastTime: time.Now(),
+	}
+}
+
+// CalculateRate calculates and returns the current rate per second.
+func (ec *EnhancedCounter) CalculateRate() float64 {
+	ec.rateMu.Lock()
+	defer ec.rateMu.Unlock()
+
+	currentValue := ec.Counter.Get()
+	currentTime := time.Now()
+
+	elapsed := currentTime.Sub(ec.lastTime).Seconds()
+	if elapsed > 0 {
+		delta := currentValue - ec.lastValue
+		ec.currentRate = float64(delta) / elapsed
+	}
+
+	ec.lastValue = currentValue
+	ec.lastTime = currentTime
+
+	return ec.currentRate
+}
+
+// GetRate returns the last calculated rate.
+func (ec *EnhancedCounter) GetRate() float64 {
+	ec.rateMu.Lock()
+	defer ec.rateMu.Unlock()
+	return ec.currentRate
+}
+
+// SafeFloat64ToBits converts float64 to uint64 bits safely.
+func SafeFloat64ToBits(f float64) uint64 {
+	return math.Float64bits(f)
+}
+
+// SafeFloat64FromBits converts uint64 bits to float64 safely.
+func SafeFloat64FromBits(b uint64) float64 {
+	return math.Float64frombits(b)
+}


### PR DESCRIPTION
Add a complete telemetry system for queue monitoring with:

Backend (Go):
- New database schema with time-series metrics storage and retention tiers
  (raw/1m/5m/1h/1d) similar to Grafana/Prometheus
- Metrics collector service with rate calculations (send/receive/delete
  per second), in-flight message tracking, and automatic aggregation
- Enhanced Prometheus metrics with new gauges, counters, and histograms
- REST API endpoints for metrics dashboard consumption (/api/v1/metrics/*)
- Support for Metabase/custom analytics via CSV/JSON export

Frontend (React):
- MetricsDashboard: System-wide overview with real-time metrics cards
- RateChart: Line/area charts for throughput visualization
- InFlightChart: In-flight message monitoring with thresholds
- QueueMetricsTable: Sortable table with per-queue metrics
- QueueDetailMetrics: Queue-specific metrics with export support
- Time range presets like Grafana (5m, 15m, 1h, 24h, 7d, 30d, etc.)

Key metrics tracked:
- Send/receive/delete rates (messages per second)
- Messages in flight (currently being processed)
- Queue depth and message visibility status
- Message processing duration and dwell time
- Batch sizes and message body sizes
- Redelivery and dead letter queue counts

https://claude.ai/code/session_01TiMNne6nTi3GXtTv7cqWaB